### PR TITLE
added nftProposalLabelWrapper & nftPoposalUserView to style.ts

### DIFF
--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -206,6 +206,8 @@ export const Style = {
       gap: 10px;
       padding: 5px 0;
     `,
+    nftProposalLabelWrapper: (_: ThemeOptionsType) => css``,
+    nftProposalUserView: (_: ThemeOptionsType) => css``,
     nftProposalLabel: (theme: ThemeOptionsType) => [
       css`
         text-transform: uppercase;

--- a/src/nft-proposal/ProposalActionList.tsx
+++ b/src/nft-proposal/ProposalActionList.tsx
@@ -50,7 +50,7 @@ export const ProposalActionList = ({
 
   return (
     <div {...getStyles("nftProposalActionList")}>
-      <div>
+      <div {...getStyles("nftProposalLabelWrapper")}>
         <div {...getStyles("nftProposalLabel")}>
           {getString("RESERVE_PRICE")}
         </div>
@@ -64,7 +64,7 @@ export const ProposalActionList = ({
         </div>
       </div>
 
-      <div>
+      <div {...getStyles("nftProposalLabelWrapper")}>
         <div {...getStyles("nftProposalLabel")}>
           {getString("PROPOSAL_CURATOR_SHARE")}
         </div>

--- a/src/nft-proposal/ProposalMediaDisplay.tsx
+++ b/src/nft-proposal/ProposalMediaDisplay.tsx
@@ -43,7 +43,7 @@ export const ProposalMediaDisplay = ({}: ProposalMediaDisplayProps) => {
       <div {...getStyles("nftProposalMediaWrapper")}>{media}</div>
       <div {...getStyles("nftProposalInfoLayout")}>
         <div {...getStyles("nftProposalTitle")}>{title}</div>
-        <div>
+        <div {...getStyles("nftProposalLabelWrapper")}>
           <div {...getStyles("nftProposalLabel")}>
             {hasCreator
               ? getString("CARD_CREATED_BY")
@@ -54,7 +54,7 @@ export const ProposalMediaDisplay = ({}: ProposalMediaDisplayProps) => {
           </div>
         </div>
         {data?.pricing.reserve?.tokenOwner && (
-          <div>
+          <div {...getStyles("nftProposalLabelWrapper")}>
             <div {...getStyles("nftProposalLabel")}>{getString("PROPOSED_BY")}</div>
             <div {...getStyles("fullOwnerAddress")}>
               {address && (

--- a/src/nft-proposal/ProposalUserView.tsx
+++ b/src/nft-proposal/ProposalUserView.tsx
@@ -11,7 +11,7 @@ export const ProposalUserView = ({ address }: ProposalUserViewProps) => {
   const username = useZoraUsername(address);
 
   return (
-    <div>
+    <div {...getStyles("nftProposalUserView")}>
       {username.username?.profile_image_url && (
         <img
           src={username.username?.profile_image_url}


### PR DESCRIPTION
In the nft-proposals components there were a couple instances of divs without selectors, i created two new keys in the styles.ts file titled: nftProposalLabelWrapper & nftProposalUserView - they have no styling - but handy to have the option to style these or at least target a selector for special use cases.