### PR TITLE
WIP: Rewrite Media Rendering Infastructure

### DIFF
--- a/src/components/MediaObject.tsx
+++ b/src/components/MediaObject.tsx
@@ -3,7 +3,10 @@ import { useNFTContent } from "@zoralabs/nft-hooks";
 
 import { useMediaContext } from "../context/useMediaContext";
 import { MediaRendererDefaultTable } from "../content-components";
-import { RendererConfig, RenderRequest } from "../content-components/RendererConfig";
+import {
+  RendererConfig,
+  RenderRequest,
+} from "../content-components/RendererConfig";
 
 type MetadataIsh = {
   mimeType: string;
@@ -36,7 +39,8 @@ export const MediaObject = ({
       content: contentURI
         ? {
             uri: contentURI,
-            type: metadata.mimeType,
+            // TODO(iain): Clean up for catalog.works
+            type: metadata.mimeType || (metadata as any).body?.mimeType,
           }
         : undefined,
       image: metadata.image
@@ -63,7 +67,7 @@ export const MediaObject = ({
         ? -1
         : 1
     );
-    console.log(sortedRenderers)
+    console.log(sortedRenderers);
     setRenderingInfo(sortedRenderers[0]);
   }, [metadata, contentURI, mediaType.content]);
 

--- a/src/components/MediaObject.tsx
+++ b/src/components/MediaObject.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect } from "react";
 import { useNFTContent } from "@zoralabs/nft-hooks";
 
 import { useMediaContext } from "../context/useMediaContext";
-import { MediaRendererDefaultTable } from "../content-components";
 import {
   RendererConfig,
   RenderRequest,
@@ -33,7 +32,7 @@ export const MediaObject = ({
 }: MediaObjectProps) => {
   const mediaType = useNFTContent(metadata.animation_url);
   const [renderingInfo, setRenderingInfo] = useState<RendererConfig>();
-  const { getStyles, getString } = useMediaContext();
+  const { getStyles, getString, renderers } = useMediaContext();
 
   const request: RenderRequest = {
     media: {
@@ -64,7 +63,7 @@ export const MediaObject = ({
   };
 
   useEffect(() => {
-    const sortedRenderers = MediaRendererDefaultTable.sort((a, b) =>
+    const sortedRenderers = renderers.sort((a, b) =>
       a.getRenderingPreference(request) > b.getRenderingPreference(request)
         ? -1
         : 1

--- a/src/components/MediaObject.tsx
+++ b/src/components/MediaObject.tsx
@@ -1,8 +1,9 @@
-import { useState, useCallback, Fragment } from "react";
+import { useState, useEffect } from "react";
 import { useNFTContent } from "@zoralabs/nft-hooks";
 
 import { useMediaContext } from "../context/useMediaContext";
-import { MediaRendererProps, RendererRecord } from "../content-components";
+import { MediaRendererDefaultTable } from "../content-components";
+import { RendererConfig, RenderRequest } from "../content-components/RendererConfig";
 
 type MetadataIsh = {
   mimeType: string;
@@ -25,102 +26,57 @@ export const MediaObject = ({
   metadata,
   isFullPage = false,
 }: MediaObjectProps) => {
-  const [mediaError, setMediaErrorMessage] = useState<undefined | string>();
-  const [mediaLoaded, setMediaLoaded] = useState<boolean>(false);
-  const [firstLoadFailed, setFirstLoadFailed] = useState<boolean>(false);
+  const mediaType = useNFTContent(metadata.animation_url);
+  const [renderingInfo, setRenderingInfo] = useState<RendererConfig>();
+  const { getStyles, getString } = useMediaContext();
 
-  const setMediaError = useCallback((error) => {
-    if (!firstLoadFailed) {
-      setFirstLoadFailed(true);
-      return;
-    }
-    setMediaErrorMessage(error.description || "Error loading content");
-  }, []);
-  const getURI = () => {
-    if (contentURI) {
-      if (firstLoadFailed) {
-        return [contentURI, metadata.mimeType];
-      }
-      // Replace main fleek instance for zora instance only with Zora NFTs
-      return [contentURI.replace("ipfs.fleek.co", "zora.fleek.co"), metadata.mimeType];
-    }
-    if (metadata.animation_url && !firstLoadFailed) {
-      return [metadata.animation_url, 'video'];
-    }
-    if (metadata.image) {
-      return [metadata.image, 'image'];
-    }
-    return [undefined, undefined];
-  };
-  const [uri, contentType] = getURI();
-  const { content } = useNFTContent(uri, contentType);
-  const { getStyles, mediaRenderers } = useMediaContext();
-
-  const getMediaObjectTag = () => {
-    const renderMediaConfig = (mediaRenderer: RendererRecord) => {
-      const mediaObject: MediaRendererProps = {
-        objectProps: {
-          ...getStyles("mediaObject", { mediaLoaded, isFullPage }),
-          src: uri,
-          alt: metadata.description,
-          onError: setMediaError,
-          onLoad: () => setMediaLoaded(true),
-        },
-        isFullPage,
-        mediaLoaded,
-        media: content,
-      };
-
-      const RendererComponent = mediaRenderer.renderer;
-      return {
-        hasLoader: mediaRenderer.hasLoader,
-        mediaTag: <RendererComponent {...mediaObject} />,
-      };
-    };
-    const handleMimePrefix = (prefix: string) => {
-      const keysToMatch = Object.keys(mediaRenderers)
-        .filter((renderKey) => renderKey.startsWith(prefix))
-        .sort(([rendererKeyA, rendererKeyB]) =>
-          rendererKeyA.length > rendererKeyB.length ? 1 : -1
-        );
-      const mediaRendererKey =
-        keysToMatch.find((key) =>
-          `${prefix}${content?.mimeType}`.startsWith(key)
-        ) || "unknown";
-      return mediaRenderers[mediaRendererKey];
-    };
-
-    // Returns in loading state
-    if (!content) {
-      return {
-        hasLoader: true,
-        mediaTag: null,
-      };
-    }
-
-    // Handles text content types
-    if (content.type === "text") {
-      return renderMediaConfig(handleMimePrefix("text:"));
-    }
-
-    // Loading error rendering
-    if (mediaError) {
-      return renderMediaConfig(mediaRenderers["error"]);
-    }
-
-    // Render content with a URI
-    return renderMediaConfig(handleMimePrefix("uri:"));
+  const request: RenderRequest = {
+    media: {
+      // from zora content uri
+      content: contentURI
+        ? {
+            uri: contentURI,
+            type: metadata.mimeType,
+          }
+        : undefined,
+      image: metadata.image
+        ? {
+            uri: metadata.image,
+            type: "image/",
+          }
+        : undefined,
+      // from metadata.animation_url
+      animation: metadata.animation_url
+        ? {
+            uri: metadata.animation_url,
+            type: mediaType.content?.mimeType,
+          }
+        : undefined,
+    },
+    metadata,
+    renderingContext: isFullPage ? "FULL" : "PREVIEW",
   };
 
-  const { hasLoader, mediaTag } = getMediaObjectTag();
-  return (
-    <Fragment>
-      {mediaTag}
-      {hasLoader && (
-        <div {...getStyles("mediaLoader", { mediaLoaded, isFullPage })}>
-          <span>Loading...</span>
-        </div>
-      )}
-    </Fragment>
-  );
+  useEffect(() => {
+    const sortedRenderers = MediaRendererDefaultTable.sort((a, b) =>
+      a.getRenderingPreference(request) > b.getRenderingPreference(request)
+        ? -1
+        : 1
+    );
+    console.log(sortedRenderers)
+    setRenderingInfo(sortedRenderers[0]);
+  }, [metadata, contentURI, mediaType.content]);
+
+  if (renderingInfo) {
+    const RenderingComponent = renderingInfo.render;
+    return (
+      <RenderingComponent
+        getStyles={getStyles}
+        getString={getString}
+        request={request}
+      />
+    );
+  }
+
+  return <span>hai</span>;
 };

--- a/src/content-components/Audio.tsx
+++ b/src/content-components/Audio.tsx
@@ -158,7 +158,6 @@ export const AudioRenderer = forwardRef<HTMLAudioElement, RenderComponentType>(
             loop={true}
             ref={audioRef}
             preload="auto"
-            autoPlay={true}
             playsInline
             onPlay={() => setPlaying(true)}
             onPause={() => setPlaying(false)}

--- a/src/content-components/Audio.tsx
+++ b/src/content-components/Audio.tsx
@@ -7,8 +7,6 @@ import {
   useState,
   forwardRef,
 } from "react";
-
-import { useMediaContext } from "../context/useMediaContext";
 import { useSyncRef } from "../utils/useSyncRef";
 import { MediaLoader, useMediaObjectProps } from "./MediaLoader";
 import {

--- a/src/content-components/Audio.tsx
+++ b/src/content-components/Audio.tsx
@@ -10,7 +10,6 @@ import {
 
 import { useMediaContext } from "../context/useMediaContext";
 import { useSyncRef } from "../utils/useSyncRef";
-import { MediaRendererProps } from ".";
 
 type FakeWaveformCanvasProps = {
   audioRef: any;
@@ -95,7 +94,7 @@ const FakeWaveformCanvas = ({
   );
 };
 
-export const Audio = forwardRef<HTMLAudioElement, MediaRendererProps>(
+export const Audio = forwardRef<HTMLAudioElement, any>(
   ({ objectProps: { onLoad, ...mediaObject }, mediaLoaded }, ref) => {
     const { getStyles } = useMediaContext();
     const audioRef = useRef<HTMLAudioElement>(null);

--- a/src/content-components/HTML.tsx
+++ b/src/content-components/HTML.tsx
@@ -1,0 +1,33 @@
+import {
+  RenderComponentType,
+  RendererConfig,
+  RenderingPreference,
+  RenderRequest,
+} from "./RendererConfig";
+
+const HTMLRenderer = ({ request, getStyles }: RenderComponentType) => (
+  <div {...getStyles("mediaContentText")}>
+    <iframe
+      style={{border: 0}}
+      width="800"
+      height="800"
+      src={request.media.content?.uri || request.media.animation?.uri}
+    ></iframe>
+  </div>
+);
+
+export const HTML: RendererConfig = {
+  getRenderingPreference(request: RenderRequest) {
+    if (
+      request.media.content?.type?.startsWith("text/html") ||
+      request.media.content?.type?.startsWith("application/pdf") ||
+      request.media.animation?.type?.startsWith("text/html")
+    ) {
+      return request.renderingContext === "FULL"
+        ? RenderingPreference.PRIORITY
+        : RenderingPreference.LOW;
+    }
+    return RenderingPreference.INVALID;
+  },
+  render: HTMLRenderer,
+};

--- a/src/content-components/HTML.tsx
+++ b/src/content-components/HTML.tsx
@@ -28,6 +28,7 @@ const HTMLRenderer = ({ request }: RenderComponentType) => {
   return (
     <MediaLoader loading={loading} error={error}>
       <iframe
+        sandbox="allow-scripts"
         height={Math.floor(windowHeight * 0.6)}
         width="100%"
         style={{ border: 0 }}

--- a/src/content-components/HTML.tsx
+++ b/src/content-components/HTML.tsx
@@ -1,3 +1,5 @@
+import { useEffect, useState } from "react";
+import { MediaLoader, useMediaObjectProps } from "./MediaLoader";
 import {
   RenderComponentType,
   RendererConfig,
@@ -5,16 +7,35 @@ import {
   RenderRequest,
 } from "./RendererConfig";
 
-const HTMLRenderer = ({ request, getStyles }: RenderComponentType) => (
-  <div {...getStyles("mediaContentText")}>
-    <iframe
-      style={{border: 0}}
-      width="800"
-      height="800"
-      src={request.media.content?.uri || request.media.animation?.uri}
-    ></iframe>
-  </div>
-);
+const HTMLRenderer = ({ request }: RenderComponentType) => {
+  const { props, loading, error } = useMediaObjectProps(
+    request.media.content?.uri || request.media.animation?.uri,
+    request
+  );
+  const [windowHeight, setWindowHeight] = useState<number>(
+    () => window.innerHeight
+  );
+  useEffect(() => {
+    const resizeHandler = () => {
+      setWindowHeight(window.innerHeight);
+    };
+    document.addEventListener("resize", resizeHandler);
+    return () => {
+      document.removeEventListener("resize", resizeHandler);
+    };
+  });
+
+  return (
+    <MediaLoader loading={loading} error={error}>
+      <iframe
+        height={Math.floor(windowHeight * 0.6)}
+        width="100%"
+        style={{ border: 0 }}
+        {...props}
+      />
+    </MediaLoader>
+  );
+};
 
 export const HTML: RendererConfig = {
   getRenderingPreference(request: RenderRequest) {

--- a/src/content-components/Image.tsx
+++ b/src/content-components/Image.tsx
@@ -1,8 +1,40 @@
 import { forwardRef } from "react";
-import { MediaRendererProps } from ".";
+import { MediaLoader, useMediaObjectProps } from "./MediaLoader";
+import {
+  RenderComponentType,
+  RendererConfig,
+  RenderingPreference,
+  RenderRequest,
+} from "./RendererConfig";
 
-export const Image = forwardRef<HTMLImageElement, MediaRendererProps>(
-  ({ objectProps }, ref) => {
-    return <img ref={ref} {...objectProps} />;
+export const ImageRenderer = forwardRef<HTMLImageElement, RenderComponentType>(
+  ({ request }, ref) => {
+    const { props, loading, error } = useMediaObjectProps(
+      request.media.content?.uri || request.media.image?.uri,
+      request
+    );
+
+    console.log({props, loading, error})
+
+    return (
+      <MediaLoader loading={loading} error={error}>
+        <img ref={ref} {...props} />
+      </MediaLoader>
+    );
   }
 );
+export const Image: RendererConfig = {
+  getRenderingPreference: (request: RenderRequest) => {
+    if (request.media.image) {
+      if (request.media.animation) {
+        return RenderingPreference.LOW;
+      }
+      return RenderingPreference.NORMAL;
+    }
+    if (request.media.content?.type?.startsWith("image/")) {
+      return RenderingPreference.NORMAL;
+    }
+    return RenderingPreference.INVALID;
+  },
+  render: ImageRenderer,
+};

--- a/src/content-components/Image.tsx
+++ b/src/content-components/Image.tsx
@@ -14,8 +14,6 @@ export const ImageRenderer = forwardRef<HTMLImageElement, RenderComponentType>(
       request
     );
 
-    console.log({props, loading, error})
-
     return (
       <MediaLoader loading={loading} error={error}>
         <img ref={ref} {...props} />

--- a/src/content-components/MediaLoader.tsx
+++ b/src/content-components/MediaLoader.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from "react";
+import { useMediaContext } from "../context/useMediaContext";
+import { RenderRequest } from "./RendererConfig";
+
+export function useMediaObjectProps(uri: string | undefined, request: RenderRequest) {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string>();
+  const { getStyles } = useMediaContext();
+
+  return {
+    loading,
+    error,
+    props: {
+      alt: request.metadata.name || request.metadata.description,
+      onLoad: () => setLoading(false),
+      // TODO(iain): Update Error
+      onError: () => setError("Error loading"),
+      src: uri,
+      ...getStyles("mediaObject", {
+        mediaLoaded: !loading,
+        isFullPage: request.renderingContext === "FULL",
+      }),
+    },
+  };
+}
+
+export const MediaLoader = ({
+  children,
+  loading,
+  error,
+}: {
+  children: React.ReactNode;
+  loading: boolean;
+  error: string | undefined;
+}) => {
+  const { getStyles } = useMediaContext();
+
+  if (!loading && !error) {
+    return <React.Fragment>{children}</React.Fragment>;
+  }
+  if (error) {
+    return (
+      <React.Fragment>
+        <span {...getStyles("mediaObjectMessage")}>Error loading content</span>
+        {children}
+      </React.Fragment>
+    );
+  }
+  return (
+    <React.Fragment>
+      <span {...getStyles("mediaLoader")}>Loading...</span>
+      {children}
+    </React.Fragment>
+  );
+};

--- a/src/content-components/RendererConfig.ts
+++ b/src/content-components/RendererConfig.ts
@@ -1,12 +1,12 @@
 import React from "react";
-import { useMediaContext } from "src/context/useMediaContext";
 
 export enum RenderingPreference {
   INVALID = -1,
   FALLBACK = 0,
   LOW = 1,
   NORMAL = 2,
-  PRIORITY = 3,
+  PREFERRED = 3,
+  PRIORITY = 4,
 }
 
 export type MediaUriType = {
@@ -36,18 +36,3 @@ export interface RendererConfig {
   getRenderingPreference(request: RenderRequest): RenderingPreference;
   render: React.FunctionComponent<RenderComponentType>;
 }
-
-// export class Audio extends RendererConfig {
-//   getRenderingPreference(request: RenderRequest) {
-//     if (request.media.content?.type?.startsWith("audio")) {
-//       return RenderingPreference.PRIORITY;
-//     }
-//     if (request.media.animation?.type?.startsWith("audio")) {
-//       return RenderingPreference.PRIORITY;
-//     }
-//     return RenderingPreference.INVALID;
-//   }
-//   render() {
-//     return [];
-//   }
-// }

--- a/src/content-components/RendererConfig.ts
+++ b/src/content-components/RendererConfig.ts
@@ -1,0 +1,53 @@
+import React from "react";
+import { useMediaContext } from "src/context/useMediaContext";
+
+export enum RenderingPreference {
+  INVALID = -1,
+  FALLBACK = 0,
+  LOW = 1,
+  NORMAL = 2,
+  PRIORITY = 3,
+}
+
+export type MediaUriType = {
+  uri: string;
+  type?: string;
+};
+
+export type RenderRequest = {
+  media: {
+    // from zora content uri
+    content?: MediaUriType;
+    image?: MediaUriType;
+    // from metadata.animation_url
+    animation?: MediaUriType;
+  };
+  metadata: any;
+  renderingContext: "PREVIEW" | "FULL";
+};
+
+export type RenderComponentType = {
+  request: RenderRequest;
+  getString: any;
+  getStyles: any;
+};
+
+export interface RendererConfig {
+  getRenderingPreference(request: RenderRequest): RenderingPreference;
+  render: React.FunctionComponent<RenderComponentType>;
+}
+
+// export class Audio extends RendererConfig {
+//   getRenderingPreference(request: RenderRequest) {
+//     if (request.media.content?.type?.startsWith("audio")) {
+//       return RenderingPreference.PRIORITY;
+//     }
+//     if (request.media.animation?.type?.startsWith("audio")) {
+//       return RenderingPreference.PRIORITY;
+//     }
+//     return RenderingPreference.INVALID;
+//   }
+//   render() {
+//     return [];
+//   }
+// }

--- a/src/content-components/Text.tsx
+++ b/src/content-components/Text.tsx
@@ -1,11 +1,31 @@
-import { useNFTContentType } from "@zoralabs/nft-hooks";
-import { useMediaContext } from "../context/useMediaContext";
+import { useNFTContent } from "@zoralabs/nft-hooks";
+import { MediaLoader } from "./MediaLoader";
+import {
+  RenderComponentType,
+  RendererConfig,
+  RenderingPreference,
+  RenderRequest,
+} from "./RendererConfig";
 
-export const Text = ({ media }: { media: useNFTContentType["content"] }) => {
-  const { getStyles } = useMediaContext();
-  return (
-    <div {...getStyles("mediaContentText")}>
-      {media?.type === "text" ? media.text : ""}
-    </div>
-  );
+export const Text: RendererConfig = {
+  getRenderingPreference: (request: RenderRequest) => {
+    if (request.media.content?.type?.startsWith("text/plain")) {
+      return RenderingPreference.PRIORITY;
+    }
+    if (request.media.content?.type?.startsWith("text/")) {
+      return RenderingPreference.LOW;
+    }
+    return RenderingPreference.INVALID;
+  },
+  render: ({ request, getStyles }: RenderComponentType) => {
+    const media = useNFTContent(request.media.content?.uri);
+
+    return (
+      <MediaLoader loading={media.content ? false : true} error={media.error}>
+        <div {...getStyles("mediaContentText")}>
+          {media.content && "text" in media.content ? media.content.text : ""}
+        </div>
+      </MediaLoader>
+    );
+  },
 };

--- a/src/content-components/Unknown.tsx
+++ b/src/content-components/Unknown.tsx
@@ -1,7 +1,21 @@
-import { MediaRendererProps } from ".";
-import { useMediaContext } from "../context/useMediaContext";
+import {
+  RenderComponentType,
+  RendererConfig,
+  RenderingPreference,
+  RenderRequest,
+} from "./RendererConfig";
 
-export const Unknown = ({ media }: MediaRendererProps) => {
-  const { getStyles } = useMediaContext();
-  return <div {...getStyles("mediaObjectMessage")}>{media?.mimeType}</div>;
+export const Unknown: RendererConfig = {
+  getRenderingPreference: (request: RenderRequest) => {
+    if (request.media.content?.type?.startsWith("text/")) {
+      return RenderingPreference.LOW;
+    }
+    return RenderingPreference.INVALID;
+  },
+
+  render: ({ request, getStyles }: RenderComponentType) => (
+    <div {...getStyles("mediaObjectMessage")}>
+      {request.media.content?.type || "unknown"}
+    </div>
+  ),
 };

--- a/src/content-components/index.ts
+++ b/src/content-components/index.ts
@@ -1,59 +1,15 @@
 import { Text } from "./Text";
-import { LoadingError } from "./LoadingError";
+import { HTML } from "./HTML";
 import { Image } from "./Image";
 import { Video } from "./Video";
-import { Audio } from "./Audio";
+// import { Audio } from "./Audio";
 import { Unknown } from "./Unknown";
-import { useNFTContentType } from "@zoralabs/nft-hooks";
 
-export type MediaRendererProps = {
-  objectProps: {
-    className: string;
-    src: string;
-    alt: string;
-    onError: () => void;
-    onLoad: () => void;
-  };
-  media: useNFTContentType["content"];
-  mediaLoaded: boolean;
-  isFullPage: boolean;
-};
 
-export type MediaRendererComponent = (
-  mediaProps: MediaRendererProps
-) => JSX.Element | null;
-
-export type RendererRecord = {
-  renderer: MediaRendererComponent;
-  hasLoader?: boolean;
-};
-export type MediaRenderersType = Record<string, RendererRecord>;
-
-// Standard is (text/uri/unknown):(mime type partial)
-// Records are sorted from most to least specific mime type when matching
-export const DefaultMediaRenderers: MediaRenderersType = {
-  "text:": {
-    renderer: Text,
-    hasLoader: false,
-  },
-  error: {
-    renderer: LoadingError,
-    hasLoader: false,
-  },
-  unknown: {
-    renderer: Unknown,
-    hasLoader: false,
-  },
-  "uri:image": {
-    renderer: Image,
-    hasLoader: true,
-  },
-  "uri:video": {
-    renderer: Video,
-    hasLoader: true,
-  },
-  "uri:audio": {
-    renderer: Audio,
-    hasLoader: true,
-  },
-};
+export const MediaRendererDefaultTable = [
+  Text,
+  HTML,
+  Image,
+  Video,
+  Unknown
+];

--- a/src/content-components/index.ts
+++ b/src/content-components/index.ts
@@ -2,11 +2,12 @@ import { Text } from "./Text";
 import { HTML } from "./HTML";
 import { Image } from "./Image";
 import { Video } from "./Video";
-// import { Audio } from "./Audio";
+import { Audio } from "./Audio";
 import { Unknown } from "./Unknown";
 
 
 export const MediaRendererDefaultTable = [
+  Audio,
   Text,
   HTML,
   Image,

--- a/src/content-components/index.ts
+++ b/src/content-components/index.ts
@@ -4,13 +4,17 @@ import { Image } from "./Image";
 import { Video } from "./Video";
 import { Audio } from "./Audio";
 import { Unknown } from "./Unknown";
+import * as RendererConfigTypes from "./RendererConfig";
 
+const MediaRendererDefaults = [Audio, Text, HTML, Image, Video, Unknown];
 
-export const MediaRendererDefaultTable = [
-  Audio,
+export {
   Text,
   HTML,
   Image,
   Video,
-  Unknown
-];
+  Audio,
+  Unknown,
+  RendererConfigTypes,
+  MediaRendererDefaults,
+};

--- a/src/context/MediaConfiguration.tsx
+++ b/src/context/MediaConfiguration.tsx
@@ -7,10 +7,10 @@ import {
 import { merge } from "merge-anything";
 
 import { Strings } from "../constants/strings";
-// import { MediaRenderersType } from "../content-components";
-
-import { MediaContext, ThemeType } from "./MediaContext";
 import { RecursivePartial } from "../utils/RecursivePartial";
+import { RendererConfig } from "../content-components/RendererConfig";
+import { MediaRendererDefaults } from "../content-components";
+import { MediaContext, ThemeType } from "./MediaContext";
 
 type MediaContextConfigurationProps = {
   /**
@@ -18,10 +18,6 @@ type MediaContextConfigurationProps = {
    */
   networkId?: NetworkIDs;
   children: React.ReactNode;
-  /**
-   * List of mediaRenderers configuration settings to add or replace media renderers.
-   */
-  // mediaRenderers?: MediaRenderersType;
   /**
    * Style configuration object. Contains both a theme and styles. Theme are generic settings for rendering styles.Style configuration object. Contains both a theme and styles.
    * Theme are generic settings for rendering styles.
@@ -32,6 +28,10 @@ type MediaContextConfigurationProps = {
    * List of content strings.
    */
   strings?: Partial<typeof Strings>;
+  /**
+   * List of renderers.
+   */
+  renderers: RendererConfig[];
 };
 
 export const MediaConfiguration = ({
@@ -39,7 +39,7 @@ export const MediaConfiguration = ({
   style = {},
   children,
   strings = {},
-  // mediaRenderers = {},
+  renderers = MediaRendererDefaults,
 }: MediaContextConfigurationProps) => {
   const superContext = useContext(MediaContext);
 
@@ -47,7 +47,7 @@ export const MediaConfiguration = ({
     // TODO(iain): Fix typing
     style: merge(superContext.style, style) as ThemeType,
     strings: merge(superContext.strings, strings),
-    // mediaRenderers: merge(superContext.mediaRenderers, mediaRenderers),
+    renderers,
     networkId,
   };
 

--- a/src/context/MediaConfiguration.tsx
+++ b/src/context/MediaConfiguration.tsx
@@ -7,7 +7,7 @@ import {
 import { merge } from "merge-anything";
 
 import { Strings } from "../constants/strings";
-import { MediaRenderersType } from "../content-components";
+// import { MediaRenderersType } from "../content-components";
 
 import { MediaContext, ThemeType } from "./MediaContext";
 import { RecursivePartial } from "../utils/RecursivePartial";
@@ -21,7 +21,7 @@ type MediaContextConfigurationProps = {
   /**
    * List of mediaRenderers configuration settings to add or replace media renderers.
    */
-  mediaRenderers?: MediaRenderersType;
+  // mediaRenderers?: MediaRenderersType;
   /**
    * Style configuration object. Contains both a theme and styles. Theme are generic settings for rendering styles.Style configuration object. Contains both a theme and styles.
    * Theme are generic settings for rendering styles.
@@ -39,7 +39,7 @@ export const MediaConfiguration = ({
   style = {},
   children,
   strings = {},
-  mediaRenderers = {},
+  // mediaRenderers = {},
 }: MediaContextConfigurationProps) => {
   const superContext = useContext(MediaContext);
 
@@ -47,7 +47,7 @@ export const MediaConfiguration = ({
     // TODO(iain): Fix typing
     style: merge(superContext.style, style) as ThemeType,
     strings: merge(superContext.strings, strings),
-    mediaRenderers: merge(superContext.mediaRenderers, mediaRenderers),
+    // mediaRenderers: merge(superContext.mediaRenderers, mediaRenderers),
     networkId,
   };
 

--- a/src/context/MediaContext.tsx
+++ b/src/context/MediaContext.tsx
@@ -3,6 +3,8 @@ import { NetworkIDs, Networks } from "@zoralabs/nft-hooks";
 
 import { Strings } from "../constants/strings";
 import { Style } from "../constants/style";
+import { MediaRendererDefaults } from "../content-components";
+import { RendererConfig } from "../content-components/RendererConfig";
 
 export type ThemeType = typeof Style;
 
@@ -10,10 +12,12 @@ export type MediaContextType = {
   style: ThemeType;
   networkId: NetworkIDs;
   strings: typeof Strings;
+  renderers: RendererConfig[];
 };
 
 export const MediaContext = createContext<MediaContextType>({
   networkId: Networks.MAINNET,
   style: Style,
   strings: Strings,
+  renderers: MediaRendererDefaults,
 });

--- a/src/context/MediaContext.tsx
+++ b/src/context/MediaContext.tsx
@@ -3,22 +3,16 @@ import { NetworkIDs, Networks } from "@zoralabs/nft-hooks";
 
 import { Strings } from "../constants/strings";
 import { Style } from "../constants/style";
-import {
-  DefaultMediaRenderers,
-  MediaRenderersType,
-} from "../content-components";
 
 export type ThemeType = typeof Style;
 
 export type MediaContextType = {
-  mediaRenderers: MediaRenderersType;
   style: ThemeType;
   networkId: NetworkIDs;
   strings: typeof Strings;
 };
 
 export const MediaContext = createContext<MediaContextType>({
-  mediaRenderers: DefaultMediaRenderers,
   networkId: Networks.MAINNET,
   style: Style,
   strings: Strings,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { Networks } from "@zoralabs/nft-hooks";
 
 import { AuctionHouseList } from "./auction-house/AuctionHouseList";
-import { NFTPreview, PreviewComponents } from "./nft-preview";
-import { NFTFullPage, FullComponents } from "./nft-full";
 import { MediaConfiguration } from "./context/MediaConfiguration";
-// import { MediaRendererProps } from "./content-components";
+import * as MediaRenderers from "./content-components";
 import { NFTDataProvider } from "./context/NFTDataProvider";
 import { MediaObject } from "./components/MediaObject";
 import { NFTDataContext } from "./context/NFTDataContext";
+import { NFTPreview, PreviewComponents } from "./nft-preview";
+import { NFTFullPage, FullComponents } from "./nft-full";
 
 export {
   // Constant list of all networks
@@ -27,6 +27,7 @@ export {
   NFTDataProvider,
   // Data context for fetching NFT info with custom components
   NFTDataContext,
-  // MediaRendererProps,
   MediaObject,
+  // Renderers and default array for configuration
+  MediaRenderers,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import { AuctionHouseList } from "./auction-house/AuctionHouseList";
 import { NFTPreview, PreviewComponents } from "./nft-preview";
 import { NFTFullPage, FullComponents } from "./nft-full";
 import { MediaConfiguration } from "./context/MediaConfiguration";
-import { MediaRendererProps } from "./content-components";
+// import { MediaRendererProps } from "./content-components";
 import { NFTDataProvider } from "./context/NFTDataProvider";
 import { MediaObject } from "./components/MediaObject";
 import { NFTDataContext } from "./context/NFTDataContext";
@@ -27,6 +27,6 @@ export {
   NFTDataProvider,
   // Data context for fetching NFT info with custom components
   NFTDataContext,
-  MediaRendererProps,
+  // MediaRendererProps,
   MediaObject,
 };

--- a/src/stories/NFTFull.stories.tsx
+++ b/src/stories/NFTFull.stories.tsx
@@ -44,6 +44,16 @@ Text.args = {
   id: "3079",
 };
 
+export const PDF = Template.bind({});
+PDF.args = {
+  id: "3327",
+};
+
+export const HTML = Template.bind({});
+HTML.args = {
+  id: "3609",
+};
+
 export const NonZoraImage = Template.bind({});
 NonZoraImage.args = {
   id: "5683",

--- a/src/stories/NFTFull.stories.tsx
+++ b/src/stories/NFTFull.stories.tsx
@@ -1,6 +1,6 @@
 import { Story, Meta } from "@storybook/react";
 import { NFTFullPage } from "../nft-full/NFTFullPage";
-import {MediaConfiguration} from "../context/MediaConfiguration";
+import { MediaConfiguration } from "../context/MediaConfiguration";
 import { Networks } from "@zoralabs/nft-hooks";
 
 export default {
@@ -9,7 +9,9 @@ export default {
 } as Meta;
 
 const Template: Story<typeof NFTFullPage> = (args) => (
-  <MediaConfiguration networkId={(args as any).testnet ? Networks.RINKEBY : Networks.MAINNET}>
+  <MediaConfiguration
+    networkId={(args as any).testnet ? Networks.RINKEBY : Networks.MAINNET}
+  >
     {/* @ts-ignore */}
     <NFTFullPage {...args} />
   </MediaConfiguration>
@@ -21,7 +23,7 @@ Image.args = {
   config: {
     showPerpetual: false,
   },
-  refreshInterval: 5000
+  refreshInterval: 5000,
 };
 
 export const Video = Template.bind({});
@@ -54,6 +56,12 @@ HTML.args = {
   id: "3609",
 };
 
+export const FND = Template.bind({});
+FND.args = {
+  id: "7685",
+  contract: "0x3b3ee1931dc30c1957379fac9aba94d1c48a5405",
+};
+
 export const NonZoraImage = Template.bind({});
 NonZoraImage.args = {
   id: "5683",
@@ -62,8 +70,8 @@ NonZoraImage.args = {
 
 export const ArtBlocks = Template.bind({});
 ArtBlocks.args = {
-  id: '83000067',
-  contract: '0x152eee3dcc5526efd646e9b45c9a9672bffcc097',
+  id: "83000067",
+  contract: "0x152eee3dcc5526efd646e9b45c9a9672bffcc097",
   testnet: true,
 };
 


### PR DESCRIPTION
This diff removes the fairly brittle initial pass of rendering and replaces it with a rendering concept of "priorites" given the raw content information and context at hand.

This allows developers to override their own priorities and subclass existing renderers. It also supports robust fallback strategies based on what data is loaded at the time of display.

1. create a priority based class system
2. abstract away and move the loading components into the renderers
3. add a HTML renderer (uses an iframe)
4. remove all the brittle code in multiple places that determined a uri and renderer seperately. now the renderer object does both

remaining work:
1. update documentation for custom renderers
2. fix custom rendering priority list configuration (add config object for easier naming lookups, use a flat list that the consumer can just pass in all renderers at once, add config class with methods)