### PR TITLE
Fix rendering hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoralabs/nft-components",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "NFT Media Rendering Components",
   "typings": "dist/index.d.ts",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoralabs/nft-components",
-  "version": "0.1.0-pre2",
+  "version": "0.1.1",
   "description": "NFT Media Rendering Components",
   "typings": "dist/index.d.ts",
   "source": "src/index.ts",

--- a/src/components/MediaObject.tsx
+++ b/src/components/MediaObject.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from "react";
 import { useNFTContent } from "@zoralabs/nft-hooks";
 
 import { useMediaContext } from "../context/useMediaContext";
-import {
+import type {
   RendererConfig,
   RenderRequest,
 } from "../content-components/RendererConfig";

--- a/src/content-components/Audio.tsx
+++ b/src/content-components/Audio.tsx
@@ -96,12 +96,12 @@ const FakeWaveformCanvas = ({ audioRef }: FakeWaveformCanvasProps) => {
 };
 
 export const AudioRenderer = forwardRef<HTMLAudioElement, RenderComponentType>(
-  ({ request, getStyles, a11yIdPrefix }, ref) => {
-    const { props, loading, error } = useMediaObjectProps(
-      request.media.content?.uri || request.media.animation?.uri,
-      request,
-      a11yIdPrefix
-    );
+  (renderProps, ref) => {
+    const {request, getStyles} = renderProps;
+    const { props, loading, error } = useMediaObjectProps({
+      uri: request.media.content?.uri || request.media.animation?.uri,
+      ...renderProps
+  });
 
     const audioRef = useRef<HTMLAudioElement>(null);
     useSyncRef(audioRef, ref);
@@ -137,7 +137,7 @@ export const AudioRenderer = forwardRef<HTMLAudioElement, RenderComponentType>(
     const playingText = playing ? "Pause" : "Play";
 
     return (
-      <MediaLoader loading={loading} error={error}>
+      <MediaLoader getStyles={getStyles} loading={loading} error={error}>
         <div ref={wrapper} {...getStyles("mediaAudioWrapper")}>
           {!loading && (
             <Fragment>

--- a/src/content-components/HTML.tsx
+++ b/src/content-components/HTML.tsx
@@ -7,11 +7,12 @@ import {
   RenderRequest,
 } from "./RendererConfig";
 
-const HTMLRenderer = ({ request }: RenderComponentType) => {
-  const { props, loading, error } = useMediaObjectProps(
-    request.media.content?.uri || request.media.animation?.uri,
-    request
-  );
+const HTMLRenderer = (requestProps: RenderComponentType) => {
+  const { getStyles, request } = requestProps;
+  const { props, loading, error } = useMediaObjectProps({
+    uri: request.media.content?.uri || request.media.animation?.uri,
+    ...requestProps,
+  });
   const [windowHeight, setWindowHeight] = useState<number>(
     () => window.innerHeight
   );
@@ -26,7 +27,7 @@ const HTMLRenderer = ({ request }: RenderComponentType) => {
   });
 
   return (
-    <MediaLoader loading={loading} error={error}>
+    <MediaLoader getStyles={getStyles} loading={loading} error={error}>
       <iframe
         sandbox="allow-scripts"
         height={Math.floor(windowHeight * 0.6)}

--- a/src/content-components/Image.tsx
+++ b/src/content-components/Image.tsx
@@ -8,15 +8,15 @@ import {
 } from "./RendererConfig";
 
 export const ImageRenderer = forwardRef<HTMLImageElement, RenderComponentType>(
-  ({ request, a11yIdPrefix }, ref) => {
-    const { props, loading, error } = useMediaObjectProps(
-      request.media.content?.uri || request.media.image?.uri,
-      request,
-      a11yIdPrefix
-    );
+  (requestProps, ref) => {
+    const { getStyles, request } = requestProps;
+    const { props, loading, error } = useMediaObjectProps({
+      uri: request.media.content?.uri || request.media.image?.uri,
+      ...requestProps,
+    });
 
     return (
-      <MediaLoader loading={loading} error={error}>
+      <MediaLoader getStyles={getStyles} loading={loading} error={error}>
         <img ref={ref} {...props} />
       </MediaLoader>
     );

--- a/src/content-components/LoadingError.tsx
+++ b/src/content-components/LoadingError.tsx
@@ -1,7 +1,4 @@
-import { useMediaContext } from "../context/useMediaContext";
-
-export const LoadingError = (_: any) => {
-  const { getStyles } = useMediaContext();
+export const LoadingError = ({ getStyles }: any) => {
   return (
     <span {...getStyles("mediaObjectMessage")}>Error loading content</span>
   );

--- a/src/content-components/MediaLoader.tsx
+++ b/src/content-components/MediaLoader.tsx
@@ -1,15 +1,19 @@
 import React, { useState } from "react";
-import { useMediaContext } from "../context/useMediaContext";
 import type { RenderRequest } from "./RendererConfig";
 
-export function useMediaObjectProps(
-  uri: string | undefined,
-  request: RenderRequest,
-  a11yIdPrefix?: string
-) {
+export function useMediaObjectProps({
+  uri,
+  request,
+  a11yIdPrefix,
+  getStyles,
+}: {
+  uri: string | undefined;
+  request: RenderRequest;
+  a11yIdPrefix?: string;
+  getStyles: any;
+}) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
-  const { getStyles } = useMediaContext();
 
   return {
     loading,
@@ -30,16 +34,16 @@ export function useMediaObjectProps(
 }
 
 export const MediaLoader = ({
+  getStyles,
   children,
   loading,
   error,
 }: {
+  getStyles: any;
   children: React.ReactNode;
   loading: boolean;
   error: string | undefined;
 }) => {
-  const { getStyles } = useMediaContext();
-
   if (!loading && !error) {
     return <React.Fragment>{children}</React.Fragment>;
   }

--- a/src/content-components/MediaLoader.tsx
+++ b/src/content-components/MediaLoader.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useMediaContext } from "../context/useMediaContext";
-import { RenderRequest } from "./RendererConfig";
+import type { RenderRequest } from "./RendererConfig";
 
 export function useMediaObjectProps(
   uri: string | undefined,

--- a/src/content-components/RendererConfig.ts
+++ b/src/content-components/RendererConfig.ts
@@ -1,5 +1,3 @@
-import React from "react";
-
 export enum RenderingPreference {
   INVALID = -1,
   FALLBACK = 0,

--- a/src/content-components/Text.tsx
+++ b/src/content-components/Text.tsx
@@ -21,7 +21,7 @@ export const Text: RendererConfig = {
     const media = useNFTContent(request.media.content?.uri);
 
     return (
-      <MediaLoader loading={media.content ? false : true} error={media.error}>
+      <MediaLoader getStyles={getStyles} loading={media.content ? false : true} error={media.error}>
         <div {...getStyles("mediaContentText")}>
           {media.content && "text" in media.content ? media.content.text : ""}
         </div>

--- a/src/content-components/Video.tsx
+++ b/src/content-components/Video.tsx
@@ -23,11 +23,12 @@ export const VideoRenderer = forwardRef<HTMLVideoElement, RenderComponentType>(
         ? request.media.animation?.uri || request.media.content?.uri
         : request.media.content?.uri || request.media.animation?.uri;
 
-    const { props, loading, error } = useMediaObjectProps(
+    const { props, loading, error } = useMediaObjectProps({
       uri,
       request,
-      a11yIdPrefix
-    );
+      a11yIdPrefix,
+      getStyles,
+    });
 
     useSyncRef(video, ref);
 
@@ -96,7 +97,7 @@ export const VideoRenderer = forwardRef<HTMLVideoElement, RenderComponentType>(
       : getString("VIDEO_CONTROLS_PLAY");
 
     return (
-      <MediaLoader loading={loading} error={error}>
+      <MediaLoader getStyles={getStyles} loading={loading} error={error}>
         {video.current && (
           <div
             aria-label={getString("VIDEO_CONTROLS_LABEL")}

--- a/src/content-components/index.ts
+++ b/src/content-components/index.ts
@@ -4,7 +4,6 @@ import { Image } from "./Image";
 import { Video } from "./Video";
 import { Audio } from "./Audio";
 import { Unknown } from "./Unknown";
-// import * as RendererConfigTypes from "./RendererConfig";
 
 export const MediaRendererDefaults = [Audio, Text, HTML, Image, Video, Unknown];
 
@@ -15,5 +14,4 @@ export {
   Video,
   Audio,
   Unknown,
-  // RendererConfigTypes,
 };

--- a/src/content-components/index.ts
+++ b/src/content-components/index.ts
@@ -4,9 +4,9 @@ import { Image } from "./Image";
 import { Video } from "./Video";
 import { Audio } from "./Audio";
 import { Unknown } from "./Unknown";
-import * as RendererConfigTypes from "./RendererConfig";
+// import * as RendererConfigTypes from "./RendererConfig";
 
-const MediaRendererDefaults = [Audio, Text, HTML, Image, Video, Unknown];
+export const MediaRendererDefaults = [Audio, Text, HTML, Image, Video, Unknown];
 
 export {
   Text,
@@ -15,6 +15,5 @@ export {
   Video,
   Audio,
   Unknown,
-  RendererConfigTypes,
-  MediaRendererDefaults,
+  // RendererConfigTypes,
 };

--- a/src/context/MediaConfiguration.tsx
+++ b/src/context/MediaConfiguration.tsx
@@ -6,9 +6,9 @@ import {
 } from "@zoralabs/nft-hooks";
 import { merge } from "merge-anything";
 
-import { Strings } from "../constants/strings";
-import { RecursivePartial } from "../utils/RecursivePartial";
-import { RendererConfig } from "../content-components/RendererConfig";
+import type { Strings } from "../constants/strings";
+import type { RecursivePartial } from "../utils/RecursivePartial";
+import type { RendererConfig } from "../content-components/RendererConfig";
 import { MediaRendererDefaults } from "../content-components";
 import { MediaContext, ThemeType } from "./MediaContext";
 

--- a/src/context/MediaContext.tsx
+++ b/src/context/MediaContext.tsx
@@ -4,7 +4,7 @@ import { NetworkIDs, Networks } from "@zoralabs/nft-hooks";
 import { Strings } from "../constants/strings";
 import { Style } from "../constants/style";
 import { MediaRendererDefaults } from "../content-components";
-import { RendererConfig } from "../content-components/RendererConfig";
+import type { RendererConfig } from "../content-components/RendererConfig";
 
 export type ThemeType = typeof Style;
 
@@ -15,6 +15,7 @@ export type MediaContextType = {
   renderers: RendererConfig[];
 };
 
+console.log({MediaRendererDefaults});
 export const MediaContext = createContext<MediaContextType>({
   networkId: Networks.MAINNET,
   style: Style,

--- a/src/context/MediaContext.tsx
+++ b/src/context/MediaContext.tsx
@@ -15,7 +15,6 @@ export type MediaContextType = {
   renderers: RendererConfig[];
 };
 
-console.log({MediaRendererDefaults});
 export const MediaContext = createContext<MediaContextType>({
   networkId: Networks.MAINNET,
   style: Style,

--- a/src/context/NFTDataContext.ts
+++ b/src/context/NFTDataContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from "react";
-import { useNFTMetadataType, useNFTType, useZNFTType} from "@zoralabs/nft-hooks";
+import type { useNFTMetadataType, useNFTType, useZNFTType} from "@zoralabs/nft-hooks";
 
 export type NFTDataContext = {
   nft: useNFTType | useZNFTType;

--- a/src/context/NFTDataProvider.tsx
+++ b/src/context/NFTDataProvider.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   DataTransformers,
   useNFT,
@@ -8,7 +7,7 @@ import {
 } from "@zoralabs/nft-hooks";
 
 import { NFTDataContext } from "./NFTDataContext";
-import {
+import type {
   OpenseaNFTDataType,
   ZNFTDataType,
 } from "@zoralabs/nft-hooks/dist/fetcher/AuctionInfoTypes";

--- a/src/context/useMediaContext.ts
+++ b/src/context/useMediaContext.ts
@@ -1,6 +1,6 @@
 import { useContext } from "react";
 import { css } from "@emotion/css";
-import { Strings } from "../constants/strings";
+import type { Strings } from "../constants/strings";
 import { MediaContext, ThemeType } from "./MediaContext";
 
 export function useMediaContext() {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,8 @@ import { Networks } from "@zoralabs/nft-hooks";
 
 import { AuctionHouseList } from "./auction-house/AuctionHouseList";
 import { MediaConfiguration } from "./context/MediaConfiguration";
-// import * as MediaRenderers from "./content-components";
+import * as MediaRenderers from "./content-components";
+import * as RendererConfigTypes from "./content-components/RendererConfig";
 import { NFTDataProvider } from "./context/NFTDataProvider";
 import { MediaObject } from "./components/MediaObject";
 import { NFTDataContext } from "./context/NFTDataContext";
@@ -29,5 +30,6 @@ export {
   NFTDataContext,
   MediaObject,
   // Renderers and default array for configuration
-  // MediaRenderers,
+  MediaRenderers,
+  RendererConfigTypes,
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { Networks } from "@zoralabs/nft-hooks";
 
 import { AuctionHouseList } from "./auction-house/AuctionHouseList";
 import { MediaConfiguration } from "./context/MediaConfiguration";
-import * as MediaRenderers from "./content-components";
+// import * as MediaRenderers from "./content-components";
 import { NFTDataProvider } from "./context/NFTDataProvider";
 import { MediaObject } from "./components/MediaObject";
 import { NFTDataContext } from "./context/NFTDataContext";
@@ -29,5 +29,5 @@ export {
   NFTDataContext,
   MediaObject,
   // Renderers and default array for configuration
-  MediaRenderers,
+  // MediaRenderers,
 };

--- a/src/nft-full/BidHistory.tsx
+++ b/src/nft-full/BidHistory.tsx
@@ -98,7 +98,7 @@ export const BidHistory = ({ showPerpetual = true }: BidHistoryProps) => {
     return eventsList
       .sort((bidA, bidB) => (bidA.createdAt > bidB.createdAt ? -1 : 1))
       .map((bidItem) => (
-        <li {...getStyles("fullPageHistoryItem")} key={bidItem.createdAt}>
+        <li {...getStyles("fullPageHistoryItem")} key={`${bidItem.actor}-${bidItem.createdAt}`}>
           <div>
             <span {...getStyles("pricingAmount")}>
               <AddressView address={bidItem.actor} />{" "}

--- a/src/nft-full/InfoContainer.tsx
+++ b/src/nft-full/InfoContainer.tsx
@@ -1,4 +1,4 @@
-import { Strings } from "../constants/strings";
+import type { Strings } from "../constants/strings";
 import { useMediaContext } from "../context/useMediaContext";
 
 export type InfoContainerProps = {

--- a/src/nft-full/ProofAuthenticity.tsx
+++ b/src/nft-full/ProofAuthenticity.tsx
@@ -1,4 +1,4 @@
-import { NFTDataType } from "@zoralabs/nft-hooks";
+import type { NFTDataType } from "@zoralabs/nft-hooks";
 import React, { useContext } from "react";
 
 import { NFTDataContext } from "../context/NFTDataContext";

--- a/src/utils/PricingString.tsx
+++ b/src/utils/PricingString.tsx
@@ -1,4 +1,4 @@
-import { PricingInfo } from "@zoralabs/nft-hooks";
+import type { PricingInfo } from "@zoralabs/nft-hooks";
 import { Fragment } from "react";
 
 import { useMediaContext } from "../context/useMediaContext";

--- a/tests/components/AuctionInfo.test.tsx
+++ b/tests/components/AuctionInfo.test.tsx
@@ -1,9 +1,10 @@
 import { readFile } from "fs/promises";
+import type { ReactNode } from "react";
 import { join } from "path";
 import { render, screen } from "@testing-library/react";
-import { FullComponents, NFTDataContext } from "../../src";
-import { ReactNode } from "react";
 import MockDate from "mockdate";
+
+import { FullComponents, NFTDataContext } from "../../src";
 import fetchMock from "./fetchMock";
 
 const loadJSON = async (name: string) => {

--- a/tests/components/BidHistory.test.tsx
+++ b/tests/components/BidHistory.test.tsx
@@ -1,9 +1,10 @@
-import { readFile } from "fs/promises";
 import { join } from "path";
+import { readFile } from "fs/promises";
 import { render, screen } from "@testing-library/react";
-import { FullComponents, NFTDataContext } from "../../src";
-import { ReactNode } from "react";
 import MockDate from "mockdate";
+import type { ReactNode } from "react";
+
+import { FullComponents, NFTDataContext } from "../../src";
 import fetchMock from "./fetchMock";
 
 const loadJSON = async (name: string) => {

--- a/tests/components/fetchMock.ts
+++ b/tests/components/fetchMock.ts
@@ -1,4 +1,4 @@
-import { FetchMockSandbox } from 'fetch-mock';
+import type { FetchMockSandbox } from 'fetch-mock';
 import crossFetch from 'cross-fetch';
 
 jest.mock('cross-fetch', () => require('fetch-mock-jest').sandbox());

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,7 +23,8 @@
     "noUnusedParameters": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "importsNotUsedAsValues": "error"
   },
   "include": ["src"],
   "exclude": ["src/stories"]


### PR DESCRIPTION
This cleans up imports and types and removes circular imports for context with the new renderer infrastructure by instead injecting needed context as props.