### PR TITLE
adding a model renderer

### DIFF
--- a/src/content-components/Model.tsx
+++ b/src/content-components/Model.tsx
@@ -1,0 +1,43 @@
+import { Fragment } from "react";
+import { HTML } from "./HTML";
+import {
+  RenderComponentType,
+  RendererConfig,
+  RenderingPreference,
+  RenderRequest,
+} from "./RendererConfig";
+
+interface ModelRenderer extends RendererConfig {
+  renderingPage: string;
+}
+
+export const Model: ModelRenderer = {
+  renderingPage:
+    "https://gateway.pinata.cloud/ipfs/QmVc3UHHL6dhjWuY4cryY3yoEu1HoX8KcFafq3K4ELbZEJ/model-viewer.html",
+  getRenderingPreference: (request: RenderRequest) => {
+    if (request.media.content?.type?.startsWith("model/gltf")) {
+      return request.renderingContext === "FULL"
+        ? RenderingPreference.PRIORITY
+        : RenderingPreference.NORMAL;
+    }
+    return RenderingPreference.INVALID;
+  },
+  render: (props: RenderComponentType) => {
+    const mediaURI =
+      props.request.media.content?.uri || props.request.media.animation?.uri;
+    if (!mediaURI) {
+      // todo: better error
+      return <Fragment />;
+    }
+    const params = new URLSearchParams();
+    params.append("src", mediaURI);
+    if (props.request.media.image) {
+      params.append("poster", props.request.media.image?.uri);
+    }
+    props.request.media.content = {
+      uri: `${Model.renderingPage}#${params.toString()}`,
+    };
+
+    return <HTML.render {...props} />;
+  },
+};

--- a/src/content-components/index.ts
+++ b/src/content-components/index.ts
@@ -1,11 +1,12 @@
-import { Text } from "./Text";
+import { Audio } from "./Audio";
 import { HTML } from "./HTML";
 import { Image } from "./Image";
-import { Video } from "./Video";
-import { Audio } from "./Audio";
+import { Model } from "./Model";
+import { Text } from "./Text";
 import { Unknown } from "./Unknown";
+import { Video } from "./Video";
 
-export const MediaRendererDefaults = [Audio, Text, HTML, Image, Video, Unknown];
+export const MediaRendererDefaults = [Model, Audio, Text, HTML, Image, Video, Unknown];
 
 export {
   Text,
@@ -13,5 +14,6 @@ export {
   Image,
   Video,
   Audio,
+  Model,
   Unknown,
 };

--- a/src/stories/NFTFull.stories.tsx
+++ b/src/stories/NFTFull.stories.tsx
@@ -75,6 +75,12 @@ ArtBlocks.args = {
   testnet: true,
 };
 
+export const ModelViewer = Template.bind({})
+ModelViewer.args = {
+  id: "3591",
+  testnet: true,
+};
+
 export const CryptoKitty = Template.bind({});
 CryptoKitty.args = {
   id: "556",


### PR DESCRIPTION
Adding a 3d model renderer view

Uses IPFS and the HTML view to load a https://modelviewer.dev/ instance.

This is fairly lightweight as a template to be expanded upon with custom controls and packages as needed by end users.

Example:
<img width="758" alt="Screen Shot 2021-08-05 at 12 06 55 AM" src="https://user-images.githubusercontent.com/835896/128289512-3f900e44-2f4b-4b64-8308-52a3d2bf917f.png">
