### PR TITLE
POC - not for merge - optional styles 

### DIFF
--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -21,6 +21,7 @@ export const Button = ({
       onClick={onClick}
       href={href}
       target={href ? "_blank" : undefined}
+      /* @ts-ignore */
       {...getStyles("button", { primary })}
     >
       {children}

--- a/src/constants/noStyle.ts
+++ b/src/constants/noStyle.ts
@@ -1,0 +1,77 @@
+import { css } from "@emotion/css";
+
+import { ThemeOptions, ThemeOptionsType } from "./theme";
+
+export const Style = {
+  theme: ThemeOptions,
+  styles: {
+    auctionHouseList: () => css``,
+    cardLink: () => css``,
+    cardHeader: () => css``,
+    cardMediaWrapper: () => css``,
+    cardItemInfo: () => css``,
+    cardAuctionPricing: () => {},
+    cardTitle: () => css``,
+    fullPage: () => css``,
+    fullMediaWrapper: () => css``,
+    fullItemInfo: () => css``,
+    fullTitle: () => css``,
+    fullDescription: () => css``,
+    fullOwnerAddress: () => css``,
+    fullLabel: () => ``,
+    fullPageHistoryItem: () => css``,
+    fullPageHistoryItemDescription: () => css``,
+    fullPageHistoryItemMeta: () => css``,
+    fullPageHistoryTxnLink: () => css``,
+    nftProposalMediaWrapper: () => css``,
+    nftProposalInfoLayout: () => css``,
+    nftProposalActionList: () => css``,
+    nftProposalLabelWrapper: () => css``,
+    nftProposalUserView: () => css``,
+    nftProposalLabel: () => css``,
+    fullPageHistoryItemDatestamp: () => css``,
+    fullPageDataGrid: () => css``,
+    infoContainer: () => css``,
+    fullInfoSpacer: () => css``,
+    fullInfoAuctionWrapper: () => ``,
+    fullPlaceOfferButton: () => css``,
+    fullInfoCreatorEquityContainer: () => css``,
+    fullInfoProofAuthenticityContainer: () => css``,
+    fullProofLink: () => css``,
+    fullCreatorOwnerSection: () => css``,
+    button: () => css``,
+    textSubdued: () => css``,
+    pricingAmount: () => css``,
+    nftProposal: () => css``,
+    nftProposalActions: () => css``,
+    nftProposalAcceptedPill: () => css``,
+    nftProposalTitle: () => css``,
+    mediaLoader: () => css``,
+    mediaObject: () => css``,
+    mediaAudioWrapper: () => css``,
+    mediaAudioWaveform: () => css``,
+    mediaObjectMessage: () => css``,
+    mediaContentText: () => css``,
+    mediaPlayButton: () => css``,
+    mediaVideoControls: () => css``,
+    mediaFullscreenButton: () => css``,
+    mediaMuteButton: () => css``,
+    /* REQUIRE ARGS */
+    nftProposalActionButton: (
+      /* @ts-ignore */
+      theme: ThemeOptionsType,
+      { action }: { action: "approve" | "deny" }
+    ) => css`
+      ${action === "approve" && ``}
+      ${action === "approve" && ``}
+      ${action === "deny" && ``}
+    `,
+    cardOuter: (
+      /* @ts-ignore */ 
+      theme: ThemeOptionsType, { hasClickEvent }: any) => css`
+      ${hasClickEvent
+        ? ``
+        : ""}
+    `,
+  },
+};

--- a/src/context/MediaContext.tsx
+++ b/src/context/MediaContext.tsx
@@ -2,7 +2,7 @@ import { createContext } from "react";
 import { NetworkIDs, Networks } from "@zoralabs/nft-hooks";
 
 import { Strings } from "../constants/strings";
-import { Style } from "../constants/style";
+import { Style } from "../constants/noStyle";
 import { MediaRendererDefaults } from "../content-components";
 import type { RendererConfig } from "../content-components/RendererConfig";
 

--- a/src/context/useMediaContext.ts
+++ b/src/context/useMediaContext.ts
@@ -7,8 +7,7 @@ export function useMediaContext() {
   const mediaContext = useContext(MediaContext);
 
   const getStyles = (
-    themeKey: keyof ThemeType["styles"],
-    flags: any = {}
+    themeKey: keyof ThemeType["styles"]
   ): any => {
     if (!(themeKey in mediaContext.style.styles)) {
       throw new Error(
@@ -17,12 +16,9 @@ export function useMediaContext() {
         ).join(", ")}]`
       );
     }
-    const styles = mediaContext.style.styles[themeKey](
-      mediaContext.style.theme,
-      flags
-    );
+    // const styles = mediaContext.style.styles[themeKey]();
     return {
-      className: `zora-${themeKey} ${css(styles)}`,
+      className: `zora-${themeKey} ${css('')}`,
     };
   };
 

--- a/src/nft-full/AuctionInfo.tsx
+++ b/src/nft-full/AuctionInfo.tsx
@@ -63,6 +63,8 @@ export const AuctionInfo = ({ showPerpetual = true }: AuctionInfoProps) => {
     return (
       <AuctionInfoWrapper titleString="AUCTION_SOLD_FOR">
         <PricingString pricing={highestPreviousBid.pricing} />
+        {/*
+          // @ts-ignore */}
         <div {...getStyles("fullInfoSpacer", { width: 15 })} />
         <div {...getStyles("fullLabel")}>{getString("WINNER")}</div>
         <AddressView address={highestPreviousBid.bidder.id} />

--- a/src/nft-full/InfoContainer.tsx
+++ b/src/nft-full/InfoContainer.tsx
@@ -15,9 +15,13 @@ export const InfoContainer = ({
   const { getStyles, getString } = useMediaContext();
 
   return (
-    <div {...getStyles("infoContainer", { bottomPadding })}>
-      <h4 {...getStyles("fullLabel")}>{getString(titleString)}</h4>
-      {children}
-    </div>
+    <>
+      {/*
+        // @ts-ignore */}
+        <div {...getStyles("infoContainer", { bottomPadding })}>
+          <h4 {...getStyles("fullLabel")}>{getString(titleString)}</h4>
+          {children}
+          </div>
+      </>
   );
 };

--- a/src/nft-preview/MediaThumbnailWrapper.tsx
+++ b/src/nft-preview/MediaThumbnailWrapper.tsx
@@ -21,7 +21,8 @@ export const MediaThumbnailWrapper = ({
 
   return (
     <div
-      {...getStyles("cardOuter", { hasClickEvent: !!onClick, auctionStatus })}
+      {...getStyles("cardOuter", /*@ts-ignore */
+        { hasClickEvent: !!onClick, auctionStatus })}
     >
       {(href || onClick) && (
         <LinkComponent {...getStyles("cardLink")} href={href} onClick={onClick}>

--- a/src/nft-preview/PricingComponent.tsx
+++ b/src/nft-preview/PricingComponent.tsx
@@ -32,16 +32,20 @@ export const PricingComponent = ({
     pricing.status === AuctionStateInfo.NO_PRICING
   ) {
     return (
-      <div {...getStyles("cardAuctionPricing", { type: "unknown" })}>
-        <div {...getStyles("textSubdued")}>{getString("RESERVE_PRICE")}</div>
-        <div {...getStyles("pricingAmount")}>
-          {getString("NO_PRICING_PLACEHOLDER")}
+      <>
+        {/*
+        // @ts-ignore */}
+        <div {...getStyles("cardAuctionPricing", { type: "unknown" })}>
+          <div {...getStyles("textSubdued")}>{getString("RESERVE_PRICE")}</div>
+          <div {...getStyles("pricingAmount")}>
+            {getString("NO_PRICING_PLACEHOLDER")}
+          </div>
+          <div {...getStyles("textSubdued")}>{getString("HIGHEST_BID")}</div>
+          <div {...getStyles("pricingAmount")}>
+            {getString("NO_PRICING_PLACEHOLDER")}
+          </div>
         </div>
-        <div {...getStyles("textSubdued")}>{getString("HIGHEST_BID")}</div>
-        <div {...getStyles("pricingAmount")}>
-          {getString("NO_PRICING_PLACEHOLDER")}
-        </div>
-      </div>
+      </>
     );
   }
 
@@ -66,30 +70,38 @@ export const PricingComponent = ({
     if (!highestBid && pricing.reserve?.previousBids.length) {
       const highestPreviousBid = pricing.reserve.previousBids[0];
       return (
-        <div {...getStyles("cardAuctionPricing", { type: "reserve-pending" })}>
-          <span {...getStyles("textSubdued")}>{getString("SOLD_FOR")}</span>
-          <span {...getStyles("pricingAmount")}>
-            <PricingString
-              pricing={highestPreviousBid.pricing}
-              showUSD={false}
-            />
-          </span>
-          {listPrice}
-        </div>
+        <>
+          {/*
+            // @ts-ignore */}
+          <div {...getStyles("cardAuctionPricing", { type: "reserve-pending" })}>
+            <span {...getStyles("textSubdued")}>{getString("SOLD_FOR")}</span>
+            <span {...getStyles("pricingAmount")}>
+              <PricingString
+                pricing={highestPreviousBid.pricing}
+                showUSD={false}
+              />
+            </span>
+            {listPrice}
+          </div>
+        </>
       );
     }
     return (
-      <div {...getStyles("cardAuctionPricing", { type: "perpetual" })}>
-        <span {...getStyles("textSubdued")}>{getString("HIGHEST_BID")}</span>
-        <span {...getStyles("pricingAmount")}>
-          {highestBid ? (
-            <PricingString showUSD={false} pricing={highestBid.pricing} />
-          ) : (
-            getString("NO_PRICING_PLACEHOLDER")
-          )}
-        </span>
-        {listPrice}
-      </div>
+      <>
+        {/*
+          // @ts-ignore */}
+        <div {...getStyles("cardAuctionPricing", { type: "perpetual" })}>
+          <span {...getStyles("textSubdued")}>{getString("HIGHEST_BID")}</span>
+          <span {...getStyles("pricingAmount")}>
+            {highestBid ? (
+              <PricingString showUSD={false} pricing={highestBid.pricing} />
+            ) : (
+              getString("NO_PRICING_PLACEHOLDER")
+            )}
+          </span>
+          {listPrice}
+        </div>
+      </>
     );
   }
   if (pricing && pricing.reserve) {
@@ -99,25 +111,29 @@ export const PricingComponent = ({
     ) {
       const highestBid = pricing.reserve?.current.highestBid;
       return (
-        <div {...getStyles("cardAuctionPricing", { type: "reserve-active" })}>
-          <span {...getStyles("textSubdued")}>{getString("TOP_BID")}</span>
-          <span {...getStyles("pricingAmount")}>
-            {highestBid && (
-              <PricingString pricing={highestBid?.pricing} showUSD={false} />
-            )}
-          </span>
-          {pricing.reserve?.expectedEndTimestamp &&
-            isInFuture(pricing.reserve.expectedEndTimestamp) && (
-              <Fragment>
-                <span {...getStyles("textSubdued")}>
-                  {getString("ENDS_IN")}
-                </span>
-                <span {...getStyles("pricingAmount")}>
-                  <CountdownDisplay to={pricing.reserve.expectedEndTimestamp} />
-                </span>
-              </Fragment>
-            )}
-        </div>
+        <>
+          {/*
+            // @ts-ignore */}
+          <div {...getStyles("cardAuctionPricing", { type: "reserve-active" })}>
+            <span {...getStyles("textSubdued")}>{getString("TOP_BID")}</span>
+            <span {...getStyles("pricingAmount")}>
+              {highestBid && (
+                <PricingString pricing={highestBid?.pricing} showUSD={false} />
+              )}
+            </span>
+            {pricing.reserve?.expectedEndTimestamp &&
+              isInFuture(pricing.reserve.expectedEndTimestamp) && (
+                <Fragment>
+                  <span {...getStyles("textSubdued")}>
+                    {getString("ENDS_IN")}
+                  </span>
+                  <span {...getStyles("pricingAmount")}>
+                    <CountdownDisplay to={pricing.reserve.expectedEndTimestamp} />
+                  </span>
+                </Fragment>
+              )}
+          </div>
+        </>
       );
     }
 
@@ -125,37 +141,49 @@ export const PricingComponent = ({
       const highestBid =
         pricing.reserve.currentBid || pricing.reserve.previousBids[0];
       return (
-        <div {...getStyles("cardAuctionPricing", { type: "reserve-finished" })}>
-          <span {...getStyles("textSubdued")}>
-            {getString("AUCTION_SOLD_FOR")}
-          </span>
-          <span {...getStyles("pricingAmount")}>
-            <PricingString showUSD={false} pricing={highestBid.pricing} />
-          </span>
-        </div>
+        <>
+          {/*
+            // @ts-ignore */}
+          <div {...getStyles("cardAuctionPricing", { type: "reserve-finished" })}>
+            <span {...getStyles("textSubdued")}>
+              {getString("AUCTION_SOLD_FOR")}
+            </span>
+            <span {...getStyles("pricingAmount")}>
+              <PricingString showUSD={false} pricing={highestBid.pricing} />
+            </span>
+          </div>
+        </>
       );
     }
     if (pricing.reserve?.reservePrice) {
       return (
-        <div {...getStyles("cardAuctionPricing", { type: "reserve-pending" })}>
-          <span {...getStyles("textSubdued")}>
-            {getString("RESERVE_PRICE")}
-          </span>
-          <span>
-            <PricingString
-              showUSD={false}
-              pricing={pricing.reserve.reservePrice}
-            />
-          </span>
-        </div>
+        <>
+          {/*
+            // @ts-ignore */}
+          <div {...getStyles("cardAuctionPricing", { type: "reserve-pending" })}>
+            <span {...getStyles("textSubdued")}>
+              {getString("RESERVE_PRICE")}
+            </span>
+            <span>
+              <PricingString
+                showUSD={false}
+                pricing={pricing.reserve.reservePrice}
+              />
+            </span>
+          </div>
+        </>
       );
     }
   }
 
   return (
-    <div {...getStyles("cardAuctionPricing", { type: "unknown" })}>
-      <div {...getStyles("textSubdued")}>{getString("PRICING_LOADING")}</div>
-      <div {...getStyles("pricingAmount")}>{getString("PRICING_LOADING")}</div>
-    </div>
+    <>
+      {/*
+        // @ts-ignore */}
+      <div {...getStyles("cardAuctionPricing", { type: "unknown" })}>
+        <div {...getStyles("textSubdued")}>{getString("PRICING_LOADING")}</div>
+        <div {...getStyles("pricingAmount")}>{getString("PRICING_LOADING")}</div>
+      </div>
+    </>
   );
 };

--- a/src/nft-proposal/ProposalActionList.tsx
+++ b/src/nft-proposal/ProposalActionList.tsx
@@ -22,12 +22,14 @@ export const ProposalActionList = ({
       return (
         <div {...getStyles("nftProposalActions")}>
           <button
+            /* @ts-ignore */
             {...getStyles("nftProposalActionButton", { action: "approve" })}
             onClick={onAccept}
           >
             approve
           </button>
           <button
+            /* @ts-ignore */
             {...getStyles("nftProposalActionButton", { action: "deny" })}
             onClick={onDeny}
           >


### PR DESCRIPTION
- quick and dirty removal of emotion styling to try with nft-webcomponents.

Lots of ts ignores as you can see - this is very far from ideal - but removes all of the styling rules from the nft components which makes styling via external stylesheet very easy.

Ideally - we could introduce a secondary build that strips out the emotion style rules - ideally not having to get too invasive across all of the components where styling is injected.