### PR TITLE
Layout cleanup

### DIFF
--- a/src/components/AddressView.tsx
+++ b/src/components/AddressView.tsx
@@ -3,18 +3,19 @@ import { useZoraUsername } from "@zoralabs/nft-hooks";
 type AddressViewProps = {
   address: string;
   showChars?: number;
+  selector?: any;
 };
 
 const PREFIX_ADDRESS = "0x";
 
-export const AddressView = ({ address, showChars = 6 }: AddressViewProps) => {
+export const AddressView = ({ address, showChars = 6, selector = {} }: AddressViewProps) => {
   const username = useZoraUsername(address);
 
   const addressFirst = address.slice(0, showChars + PREFIX_ADDRESS.length);
   const addressLast = address.slice(address.length - showChars);
 
   if (username.username?.username) {
-    return <span>{`@${username.username.username}`}</span>;
+    return <span {...selector}>{`@${username.username.username}`}</span>;
   }
   if (!username.error && !username.username) {
     return <span>...</span>;

--- a/src/components/AddressView.tsx
+++ b/src/components/AddressView.tsx
@@ -26,7 +26,7 @@ export const AddressView = ({ address, showChars = 6 }: AddressViewProps) => {
     return <span>...</span>;
   }
   return (
-    <a {...getStyles("addressLink")} href={`https://zora.co/${address}`} target="_blank">
+    <a {...getStyles("addressLink")} href={`https://etherscan.io/address/${address}`} target="_blank">
       <span>
         {addressFirst}...{addressLast}
       </span>

--- a/src/components/AddressView.tsx
+++ b/src/components/AddressView.tsx
@@ -17,7 +17,12 @@ export const AddressView = ({ address, showChars = 6 }: AddressViewProps) => {
 
   if (username.username?.username) {
     return (
-      <a {...getStyles("addressLink")} href={`https://zora.co/${username.username.username}`} target="_blank">
+      <a
+        {...getStyles("addressLink")}
+        href={`https://zora.co/${username.username.username}`}
+        target="_blank"
+        rel="noreferrer"
+      >
         <span>{`@${username.username.username}`}</span>
       </a>
     );
@@ -26,7 +31,12 @@ export const AddressView = ({ address, showChars = 6 }: AddressViewProps) => {
     return <span>...</span>;
   }
   return (
-    <a {...getStyles("addressLink")} href={`https://etherscan.io/address/${address}`} target="_blank">
+    <a
+      {...getStyles("addressLink")}
+      href={`https://etherscan.io/address/${address}`}
+      target="_blank"
+      rel="noreferrer"
+    >
       <span>
         {addressFirst}...{addressLast}
       </span>

--- a/src/components/AddressView.tsx
+++ b/src/components/AddressView.tsx
@@ -1,28 +1,35 @@
 import { useZoraUsername } from "@zoralabs/nft-hooks";
+import { useMediaContext } from "../context/useMediaContext";
 
 type AddressViewProps = {
   address: string;
   showChars?: number;
-  selector?: any;
 };
 
 const PREFIX_ADDRESS = "0x";
 
-export const AddressView = ({ address, showChars = 6, selector = {} }: AddressViewProps) => {
+export const AddressView = ({ address, showChars = 6 }: AddressViewProps) => {
+  const { getStyles } = useMediaContext();
   const username = useZoraUsername(address);
 
   const addressFirst = address.slice(0, showChars + PREFIX_ADDRESS.length);
   const addressLast = address.slice(address.length - showChars);
 
   if (username.username?.username) {
-    return <span {...selector}>{`@${username.username.username}`}</span>;
+    return (
+      <a {...getStyles("addressLink")} href={`https://zora.co/${username.username.username}`} target="_blank">
+        <span>{`@${username.username.username}`}</span>
+      </a>
+    );
   }
   if (!username.error && !username.username) {
     return <span>...</span>;
   }
   return (
-    <span>
-      {addressFirst}...{addressLast}
-    </span>
+    <a {...getStyles("addressLink")} href={`https://zora.co/${address}`} target="_blank">
+      <span>
+        {addressFirst}...{addressLast}
+      </span>
+    </a>
   );
 };

--- a/src/constants/strings.ts
+++ b/src/constants/strings.ts
@@ -114,9 +114,9 @@ export const Strings = {
   CURATOR_FEE: "Curator fee",
   /**
    * Header showing curator information on NFT full page
-   * @default  of proceeds go to the curator
+   * @default  of proceeds go to
    */
-  CURATOR_PROCEEDS_DESC: " of proceeds go to the curator",
+  CURATOR_PROCEEDS_DESC: " of proceeds go to",
   /**
    * Sold for view on full view page auction info box
    * @default Sold for

--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -12,15 +12,6 @@ import {
 } from "./svg-icons";
 import { ThemeOptions, ThemeOptionsType } from "./theme";
 
-const pricingLayout = (theme: ThemeOptionsType) => css`
-  display: grid;
-  grid-auto-flow: column;
-  grid-template-rows: auto auto;
-  grid-auto-column: 1fr;
-  padding: ${theme.textBlockPadding};
-  border-top: ${theme.borderStyle};
-`;
-
 const buttonCommonSize = (size: string) => `
   padding: ${size};
   width: ${size};
@@ -343,12 +334,16 @@ export const Style = {
         position: absolute;
       }
     `,
-    fullCreatorOwnerSection: (theme: ThemeOptionsType) => [
-      pricingLayout(theme),
-      css`
-        border-top: 0;
-      `,
-    ],
+    fullCreatorOwnerSection: (theme: ThemeOptionsType) => css`
+      display: grid;
+      grid-auto-flow: column;
+      grid-template-rows: auto auto;
+      grid-auto-columns: 1fr;
+      padding: 20px;
+      border: ${theme.borderStyle};
+      border-radius: ${theme.defaultBorderRadius}px;
+      margin: 20px 0 0;
+    `,
     // Generic styles
     button: (theme: ThemeOptionsType, { primary }: any) => css`
       ${buttonReset}

--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -145,17 +145,17 @@ export const Style = {
         grid-auto-column: 1fr;
         padding: ${theme.textBlockPadding};
         border-top: ${theme.borderStyle};
-        ${getActiveStyle()}
+        ${getActiveStyle()};
       `;
     },
     cardTitle: (theme: ThemeOptionsType) => css`
       font-size: inherit;
       margin: 0;
-      max-width: calc(${theme.previewCard.width} - 30px),
+      max-width: calc(${theme.previewCard.width} - 30px);
       overflow: hidden;
       text-overflow: ellipsis;
       white-space: nowrap;
-      ${theme.titleFont}
+      ${theme.titleFont};
     `,
     // Styles for full-page view
     fullPage: (theme: ThemeOptionsType) => theme.bodyFont,
@@ -227,7 +227,7 @@ export const Style = {
         opacity: 0.8;
         background-repeat: no-repeat;
         background-position: center;
-        top: 0;
+        top: 2px;
         z-index: 10;
         right: 0;
         transition: opacity 0.4s ease-in;
@@ -366,7 +366,14 @@ export const Style = {
       `,
       theme.bodyFont,
     ],
-    pricingAmount: (theme: ThemeOptionsType) => theme.titleFont,
+    pricingAmount: (theme: ThemeOptionsType) => theme.bodyFont,
+    addressLink: (theme: ThemeOptionsType) => [
+      css`
+        text-decoration: none;
+        color: ${theme.linkColor};
+      `,
+      theme.titleFont,
+    ],
     nftProposal: (theme: ThemeOptionsType) => css`
       border: ${theme.borderStyle};
       border-radius: ${theme.defaultBorderRadius}px;

--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -199,8 +199,14 @@ export const Style = {
       theme.bodyFont,
     ],
     // CSS Class for restyling and targeting
-    fullPageHistoryItemDescription: (theme: ThemeOptionsType) => css`
-      ${theme.showTxnLinks ? "margin-right: 20px;" : ""}
+    fullPageHistoryItemDescription: () => css`
+      display: flex;
+      flex-direction: row;
+      justify-content: space-between;
+    `,
+    fullPageHistoryItemDescriptionCopy: () => css`
+      display: flex;
+      flex-direction: row;
     `,
     fullPageHistoryItemMeta: () => css`
       position: relative;
@@ -221,7 +227,7 @@ export const Style = {
         opacity: 0.8;
         background-repeat: no-repeat;
         background-position: center;
-        top: 14px;
+        top: 0;
         z-index: 10;
         right: 0;
         transition: opacity 0.4s ease-in;

--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -313,6 +313,9 @@ export const Style = {
     `,
     fullInfoCuratorFeeContainer: (_: any) => css`
       margin-top: 20px;
+      display: flex;
+      flex-direction: row;
+      flex-wrap: wrap;
     `,
     fullInfoProofAuthenticityContainer: (_: any) => css`
       margin-top: 20px;

--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -181,9 +181,13 @@ export const Style = {
       `,
       theme.bodyFont,
     ],
+    fullPageHistoryList: () => css`
+      padding: 0;
+      margin: 0;
+    `,
     fullPageHistoryItem: (theme: ThemeOptionsType) => [
       css`
-        margin-top: 14px;
+        margin-top: 15px;
         display: flex;
         flex-direction: column;
         font-weight: 300;
@@ -300,11 +304,8 @@ export const Style = {
     `,
     fullInfoAuctionWrapper: () => ``,
     fullPlaceOfferButton: (_: any) => css``,
-    fullInfoCreatorEquityContainer: (_: any) => css`
-      margin-top: 20px;
-    `,
+    fullInfoCreatorEquityContainer: (_: any) => css``,
     fullInfoCuratorFeeContainer: (_: any) => css`
-      margin-top: 20px;
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;

--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -208,6 +208,7 @@ export const Style = {
     fullPageHistoryItemDescriptionCopy: () => css`
       display: flex;
       flex-direction: row;
+      flex-wrap: wrap;
     `,
     fullPageHistoryItemMeta: () => css`
       position: relative;

--- a/src/constants/style.ts
+++ b/src/constants/style.ts
@@ -134,7 +134,7 @@ export const Style = {
         display: grid;
         grid-auto-flow: column;
         grid-template-rows: auto auto;
-        grid-auto-column: 1fr;
+        grid-auto-columns: 1fr;
         padding: ${theme.textBlockPadding};
         border-top: ${theme.borderStyle};
         ${getActiveStyle()};
@@ -156,10 +156,10 @@ export const Style = {
       position: relative;
     `,
     fullItemInfo: (_: ThemeOptionsType) => css``,
-    fullTitle: (_: ThemeOptionsType) => css`
+    fullTitle: (theme: ThemeOptionsType) => css`
       font-weight: inherit;
       font-size: 30px;
-      margin: 20px 0;
+      margin: ${theme.spacingUnit} 0;
     `,
     fullDescription: (theme: ThemeOptionsType) => css`
       font-size: ${theme.fontSizeFull}px;
@@ -288,15 +288,15 @@ export const Style = {
       `,
       theme.bodyFont,
     ],
-    fullPageDataGrid: (_: ThemeOptionsType) => css`
+    fullPageDataGrid: (theme: ThemeOptionsType) => css`
       display: grid;
-      grid-gap: 20px;
+      grid-gap: ${theme.spacingUnit};
     `,
     infoContainer: (theme: ThemeOptionsType, { bottomPadding }: any) =>
       css`
         border: ${theme.borderStyle};
         border-radius: ${theme.defaultBorderRadius}px;
-        padding: 20px 20px ${bottomPadding ? "20px" : 0};
+        padding: ${theme.spacingUnit} ${theme.spacingUnit} ${bottomPadding ? theme.spacingUnit : 0};
         position: relative;
       `,
     fullInfoSpacer: (_: any, { height = 15 }: { height: number }) => css`
@@ -310,15 +310,15 @@ export const Style = {
       flex-direction: row;
       flex-wrap: wrap;
     `,
-    fullInfoProofAuthenticityContainer: (_: any) => css`
-      margin-top: 20px;
+    fullInfoProofAuthenticityContainer: (theme: ThemeOptionsType) => css`
+      margin-top: ${theme.spacingUnit};
     `,
     fullProofLink: (theme: ThemeOptionsType) => css`
       display: block;
       text-decoration: none;
       color: ${theme.linkColor};
-      padding: 20px;
-      margin: 0 -20px;
+      padding: ${theme.spacingUnit};
+      margin: 0 -${theme.spacingUnit};
       border-top: ${theme.borderStyle};
 
       :hover {
@@ -331,7 +331,7 @@ export const Style = {
         opacity: 0.5;
         ${renderSVG(SVG_NEXT_ICON)}
         color: #eee;
-        right: 20px;
+        right: ${theme.spacingUnit};
         position: absolute;
       }
     `,
@@ -340,10 +340,10 @@ export const Style = {
       grid-auto-flow: column;
       grid-template-rows: auto auto;
       grid-auto-columns: 1fr;
-      padding: 20px;
+      padding: ${theme.spacingUnit};
       border: ${theme.borderStyle};
       border-radius: ${theme.defaultBorderRadius}px;
-      margin: 20px 0 0;
+      margin: ${theme.spacingUnit} 0 0;
     `,
     // Generic styles
     button: (theme: ThemeOptionsType, { primary }: any) => css`
@@ -379,7 +379,7 @@ export const Style = {
       border: ${theme.borderStyle};
       border-radius: ${theme.defaultBorderRadius}px;
       display: flex;
-      padding: 20px;
+      padding: ${theme.spacingUnit};
     `,
     nftProposalActions: () => css`
       grid-area: 1 / 2 / span 1 / span 2;
@@ -467,7 +467,7 @@ export const Style = {
       css`
         white-space: pre;
         text-align: left;
-        padding: 20px;
+        padding: ${theme.spacingUnit};
         width: 100%;
       `,
       theme.mediaContentFont,
@@ -495,13 +495,13 @@ export const Style = {
       `
         : "display: none;"}
     `,
-    mediaFullscreenButton: (_: ThemeOptionsType) => css`
-      ${buttonCommonSize("20px")}
+    mediaFullscreenButton: (theme: ThemeOptionsType) => css`
+      ${buttonCommonSize(theme.spacingUnit)}
       background-color: #000;
       ${renderSVG(SVG_FULLSCREEN)}
     `,
-    mediaMuteButton: (_: ThemeOptionsType, { muted }: any) => css`
-      ${buttonCommonSize("20px")}
+    mediaMuteButton: (theme: ThemeOptionsType, { muted }: any) => css`
+      ${buttonCommonSize(theme.spacingUnit)}
       background-color: #000;
       background-image: url("data:image/svg+xml,${encodeURIComponent(
         muted ? SVG_UNMUTED : SVG_MUTED

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -37,6 +37,12 @@ export const ThemeOptions = {
 
   /**
    * Padding for preview card text block
+   * @default 20px
+   */
+  spacingUnit: "20px",
+  
+  /**
+   * Padding for preview card text block
    * @default 10px 15px
    */
   textBlockPadding: "10px 15px",

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -15,6 +15,20 @@ export const ThemeOptions = {
   },
 
   /**
+   * Flag if showing the nft creator on full view
+   * should be enabled
+   * @default true
+   */
+  showCreator: true,
+   
+  /**
+   * Flag if showing the nft owner on full view
+   * should be enabled
+   * @default true
+   */
+  showOwner: true,
+  
+  /**
    * Flag if showing transaction history links on full view
    * should be enabled
    * @default true

--- a/src/context/useMediaContext.ts
+++ b/src/context/useMediaContext.ts
@@ -6,7 +6,7 @@ import { camelCase } from '../utils/camelCase'
 
 export function useMediaContext() {
   const mediaContext = useContext(MediaContext);
-
+  
   const getStyles = (
     themeKey: keyof ThemeType["styles"],
     flags: any = {}

--- a/src/nft-full/AuctionInfo.tsx
+++ b/src/nft-full/AuctionInfo.tsx
@@ -17,7 +17,7 @@ type AuctionInfoProps = {
 
 export const AuctionInfo = ({ showPerpetual = true }: AuctionInfoProps) => {
   const { nft } = useContext(NFTDataContext);
-  const { getStyles, getString } = useMediaContext();
+  const { getStyles, getString, style } = useMediaContext();
 
   const AuctionInfoWrapper = ({
     children,
@@ -83,10 +83,10 @@ export const AuctionInfo = ({ showPerpetual = true }: AuctionInfoProps) => {
     return (
       <AuctionInfoWrapper titleString="AUCTION_ENDS">
         <CountdownDisplay to={reserve.expectedEndTimestamp} />
-        <div style={{ height: "20px" }} />
+        <div style={{ height: style.theme.spacingUnit }} />
         <div {...getStyles("fullLabel")}>{getString("HIGHEST_BID")}</div>
         <PricingString pricing={reserve.current.highestBid.pricing} />
-        <div style={{ height: "20px" }} />
+        <div style={{ height: style.theme.spacingUnit }} />
         <div {...getStyles("fullLabel")}>{getString("BIDDER")}</div>
         <AddressView address={reserve.current.highestBid?.placedBy} />
       </AuctionInfoWrapper>
@@ -127,7 +127,7 @@ export const AuctionInfo = ({ showPerpetual = true }: AuctionInfoProps) => {
             <>
               <PricingString pricing={data.pricing.reserve.reservePrice} />
               <div>
-              <div style={{ height: "20px" }} />
+              <div style={{ height: style.theme.spacingUnit }} />
                 <div {...getStyles("fullLabel")}>{getString("AUCTION_PENDING_DURATION")}</div>
                 <DurationDisplay duration={data.pricing.reserve.duration} />
               </div>

--- a/src/nft-full/BidHistory.tsx
+++ b/src/nft-full/BidHistory.tsx
@@ -128,6 +128,7 @@ export const BidHistory = ({ showPerpetual = true }: BidHistoryProps) => {
                 {...getStyles("fullPageHistoryTxnLink")}
                 href={`https://etherscan.io/tx/${bidItem.transactionHash}`}
                 target="_blank"
+                rel="noreferrer"
               >
                 {getString("BID_HISTORY_VIEW_TRANSACTION")}
               </a>

--- a/src/nft-full/BidHistory.tsx
+++ b/src/nft-full/BidHistory.tsx
@@ -149,7 +149,7 @@ export const BidHistory = ({ showPerpetual = true }: BidHistoryProps) => {
 
   return (
     <InfoContainer titleString="NFT_HISTORY">
-      <ol style={{ padding: 0 }}>{getPastBids()}</ol>
+      <ol {...getStyles("fullPageHistoryList")}>{getPastBids()}</ol>
     </InfoContainer>
   );
 };

--- a/src/nft-full/BidHistory.tsx
+++ b/src/nft-full/BidHistory.tsx
@@ -120,7 +120,7 @@ export const BidHistory = ({ showPerpetual = true }: BidHistoryProps) => {
         >
           <div {...getStyles("fullPageHistoryItemDescription")}>
             <div {...getStyles("fullPageHistoryItemDescriptionCopy")}>
-              <AddressView selector={{...getStyles("pricingAmount")}} address={bidItem.actor} />&nbsp;
+              <AddressView address={bidItem.actor} />&nbsp;
               <span {...getStyles("pricingAmount")}>{bidItem.activityDescription} {bidItem.pricing}</span>
             </div>
             {bidItem.transactionHash && style.theme.showTxnLinks && (

--- a/src/nft-full/BidHistory.tsx
+++ b/src/nft-full/BidHistory.tsx
@@ -119,10 +119,19 @@ export const BidHistory = ({ showPerpetual = true }: BidHistoryProps) => {
           key={`${bidItem.actor}-${bidItem.createdAt}`}
         >
           <div {...getStyles("fullPageHistoryItemDescription")}>
-            <span {...getStyles("pricingAmount")}>
-              <AddressView address={bidItem.actor} />{" "}
-            </span>
-            {bidItem.activityDescription} {bidItem.pricing}
+            <div {...getStyles("fullPageHistoryItemDescriptionCopy")}>
+              <AddressView selector={{...getStyles("pricingAmount")}} address={bidItem.actor} />&nbsp;
+              <span {...getStyles("pricingAmount")}>{bidItem.activityDescription} {bidItem.pricing}</span>
+            </div>
+            {bidItem.transactionHash && style.theme.showTxnLinks && (
+              <a
+                {...getStyles("fullPageHistoryTxnLink")}
+                href={`https://etherscan.io/tx/${bidItem.transactionHash}`}
+                target="_blank"
+              >
+                {getString("BID_HISTORY_VIEW_TRANSACTION")}
+              </a>
+            )}
           </div>
           {bidItem.createdAt && (
             <div {...getStyles("fullPageHistoryItemMeta")}>
@@ -132,15 +141,6 @@ export const BidHistory = ({ showPerpetual = true }: BidHistoryProps) => {
               >
                 {formatDate(bidItem.createdAt)}
               </time>
-              {bidItem.transactionHash && style.theme.showTxnLinks && (
-                <a
-                  {...getStyles("fullPageHistoryTxnLink")}
-                  href={`https://etherscan.io/tx/${bidItem.transactionHash}`}
-                  target="_blank"
-                >
-                  {getString("BID_HISTORY_VIEW_TRANSACTION")}
-                </a>
-              )}
             </div>
           )}
         </li>

--- a/src/nft-full/CreatorEquity.tsx
+++ b/src/nft-full/CreatorEquity.tsx
@@ -27,10 +27,8 @@ export const CreatorEquity = () => {
       {data && data.pricing.reserve && data.pricing.reserve?.curatorFeePercentage > 0 && (
         <InfoContainer titleString="CURATOR_FEE">
           <div {...getStyles("fullInfoCuratorFeeContainer")}>
-            <p>{getContent(data.pricing.reserve?.curatorFeePercentage)} {getString('CURATOR_PROCEEDS_DESC')}</p>
-            <p>
-              <AddressView address={data.pricing.reserve.curator.id} />
-            </p>
+            <span>{getContent(data.pricing.reserve?.curatorFeePercentage)} {getString('CURATOR_PROCEEDS_DESC')}</span>
+            &nbsp;<AddressView address={data.pricing.reserve.curator.id} />
           </div>
         </InfoContainer>
       )}

--- a/src/nft-full/MediaInfo.tsx
+++ b/src/nft-full/MediaInfo.tsx
@@ -9,7 +9,7 @@ type MediaInfoProps = {
 };
 
 export const MediaInfo = ({ a11yIdPrefix }: MediaInfoProps) => {
-  const { getStyles, getString } = useMediaContext();
+  const { getStyles, getString, style } = useMediaContext();
   const {
     nft: { data },
     metadata: { metadata, error },
@@ -41,20 +41,27 @@ export const MediaInfo = ({ a11yIdPrefix }: MediaInfoProps) => {
       <div id={`${a11yIdPrefix}description`} {...getStyles("fullDescription")}>
         {description}
       </div>
-      <dl {...getStyles("fullCreatorOwnerSection")}>
-        {data?.nft.creator && (
-          <Fragment>
-            <dt {...getStyles("fullLabel")}>{getString("CREATOR")}</dt>
-            <dd {...getStyles("fullOwnerAddress")}>
-              {data ? <AddressView address={data.nft.creator} /> : " "}
-            </dd>
-          </Fragment>
-        )}
-        <dt {...getStyles("fullLabel")}>{getString("OWNER")}</dt>
-        <dd {...getStyles("fullOwnerAddress")}>
-          {data ? <AddressView address={data.nft.owner} /> : " "}
-        </dd>
-      </dl>
+      {!style.theme.showCreator && !style.theme.showOwner 
+        ?  <Fragment/>
+        :  <dl {...getStyles("fullCreatorOwnerSection")}>
+            {data?.nft.creator && style.theme.showCreator && (
+              <Fragment>
+                <dt {...getStyles("fullLabel")}>{getString("CREATOR")}</dt>
+                <dd {...getStyles("fullOwnerAddress")}>
+                  {data ? <AddressView address={data.nft.creator} /> : " "}
+                </dd>
+              </Fragment>
+            )}
+            {data?.nft.creator && style.theme.showOwner && (
+              <Fragment>
+                <dt {...getStyles("fullLabel")}>{getString("OWNER")}</dt>
+                <dd {...getStyles("fullOwnerAddress")}>
+                  {data ? <AddressView address={data.nft.owner} /> : " "}
+                </dd>
+              </Fragment>
+            )}
+          </dl>
+      }
     </div>
   );
 };

--- a/src/nft-full/ProofAuthenticity.tsx
+++ b/src/nft-full/ProofAuthenticity.tsx
@@ -18,7 +18,12 @@ const ProofLink = ({
   children: string;
   styles: any;
 }) => (
-  <a {...styles} href={href} target="_blank">
+  <a
+    {...styles}
+    href={href}
+    target="_blank"
+    rel="noreferrer"
+  >
     {children}
   </a>
 );

--- a/tests/components/BidHistory.test.tsx
+++ b/tests/components/BidHistory.test.tsx
@@ -138,7 +138,8 @@ describe("AuctionInfo", () => {
       );
 
       const wonArea = await screen.findByText("won the auction");
-      expect(wonArea.parentElement?.innerHTML).toContain("May 14, 10:23 PM");
+      
+      expect(wonArea.parentElement?.parentElement?.parentElement?.innerHTML).toContain("May 14, 10:23 PM");
       await screen.findByText("minted the NFT");
       await screen.findByText("listed the NFT");
       expect(getBids()).toEqual(["0.4 ETH"]);
@@ -153,7 +154,7 @@ describe("AuctionInfo", () => {
       );
 
       const wonArea = await screen.findByText("won the auction");
-      expect(wonArea.parentElement?.innerHTML).toContain("June 11, 12:25 PM");
+      expect(wonArea.parentElement?.parentElement?.parentElement?.innerHTML).toContain("June 11, 12:25 PM");
       await screen.findByText("minted the NFT");
       await screen.findByText("listed the NFT");
     });

--- a/tests/components/BidHistory.test.tsx
+++ b/tests/components/BidHistory.test.tsx
@@ -137,9 +137,7 @@ describe("AuctionInfo", () => {
         </TestHarness>
       );
 
-      const wonArea = await screen.findByText("won the auction");
-      
-      expect(wonArea.parentElement?.parentElement?.parentElement?.innerHTML).toContain("May 14, 10:23 PM");
+      await screen.findAllByText("May 14, 10:23 PM");
       await screen.findByText("minted the NFT");
       await screen.findByText("listed the NFT");
       expect(getBids()).toEqual(["0.4 ETH"]);
@@ -153,8 +151,7 @@ describe("AuctionInfo", () => {
         </TestHarness>
       );
 
-      const wonArea = await screen.findByText("won the auction");
-      expect(wonArea.parentElement?.parentElement?.parentElement?.innerHTML).toContain("June 11, 12:25 PM");
+      await screen.findAllByText("June 11, 12:25 PM");
       await screen.findByText("minted the NFT");
       await screen.findByText("listed the NFT");
     });


### PR DESCRIPTION
1. AddressView - added href tag linking out to zora.co profile for both username & wallet address... there's no explicit styling on the link tag, functions same way it does in .co
2. refactored layout in bid history - the arrow placement is now correct, although have not tested this in create-auction-house template yet (where alan noticed the layout bug)
3. refactored creator equity layout to all be on a single row, changed the default text string to read "x% of proceeds go to"