### PR TITLE
Collection Tag in full page component

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.1.19] - 2021-11-04
 - Adding ens and zora username resolution flags to AddressView
+- updating nft-hooks lib version
 
 ## [0.1.18] - 2021-11-01
 - Correctly bumping nft-hooks version to fix ipfs:// data content fetch uri replacement

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.18] - 2021-11-01
+- Correctly bumping nft-hooks version to fix ipfs:// data content fetch uri replacement
+
 ## [0.1.16] - 2021-10-29
 - Fix display username instead of user.name in addressview
 - Bumping nft-hooks to fix ipfs:// data content fetch uri replacement

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Adding ens and zora username resolution flags to AddressView
 
 ## [0.1.18] - 2021-11-01
 - Correctly bumping nft-hooks version to fix ipfs:// data content fetch uri replacement

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoralabs/nft-components",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "NFT Media Rendering Components",
   "typings": "dist/index.d.ts",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoralabs/nft-components",
-  "version": "0.1.15",
+  "version": "0.1.19",
   "description": "NFT Media Rendering Components",
   "typings": "dist/index.d.ts",
   "source": "src/index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zoralabs/nft-components",
-  "version": "0.1.18",
+  "version": "0.1.19",
   "description": "NFT Media Rendering Components",
   "typings": "dist/index.d.ts",
   "source": "src/index.ts",
@@ -15,7 +15,7 @@
   "dependencies": {
     "@emotion/css": "^11.1.3",
     "@types/react": "^17.0.5",
-    "@zoralabs/nft-hooks": "^0.7.1",
+    "@zoralabs/nft-hooks": "^0.7.2",
     "merge-anything": "^4.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/components/AddressView.tsx
+++ b/src/components/AddressView.tsx
@@ -4,26 +4,24 @@ import { useMediaContext } from "../context/useMediaContext";
 type AddressViewProps = {
   address: string;
   showChars?: number;
-  useEns?: boolean;
 };
 
 const PREFIX_ADDRESS = "0x";
 
-export const AddressView = ({
-  address,
-  showChars = 6,
-  useEns = true,
-}: AddressViewProps) => {
-  const { getStyles } = useMediaContext();
+export const AddressView = ({ address, showChars = 6 }: AddressViewProps) => {
+  const { getStyles, style } = useMediaContext();
+  const { theme } = style;
   // @ts-ignore (address can be undefined but not typed correctly for now)
-  const ens = useENSAddress(useEns ? address : undefined);
-  const username = useZoraUsername(!useEns || ens.error ? address : undefined);
+  const ens = useENSAddress(theme.useEnsResolution ? address : undefined);
+  const username = useZoraUsername(
+    theme.useZoraUsernameResolution || ens.error ? address : undefined
+  );
 
   const addressFirst = address.slice(0, showChars + PREFIX_ADDRESS.length);
   const addressLast = address.slice(address.length - showChars);
 
   if (ens.data?.name) {
-    const zoraLink = ens.data.name.endsWith('.ens') ? ens.data.name : address;
+    const zoraLink = ens.data.name.endsWith(".ens") ? ens.data.name : address;
     return (
       <a
         {...getStyles("addressLink")}
@@ -49,12 +47,16 @@ export const AddressView = ({
   }
 
   // Username loading
-  if (!username.error && !username.username) {
+  if (
+    theme.useZoraUsernameResolution &&
+    !username.error &&
+    !username.username
+  ) {
     return <span>...</span>;
   }
 
   // Ens loading
-  if (useEns && !ens.error && !ens.data) {
+  if (theme.useEnsResolution && !ens.error && !ens.data) {
     return <span>...</span>;
   }
 

--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -20,6 +20,18 @@ export const ThemeOptions = {
    * @default true
    */
   showCreator: true,
+
+  /**
+   * Flag if ens resolution should be automatically used
+   * @default true
+   */
+  useEnsResolution: true,
+
+  /**
+   * Flag if zora username resolution should be automatically used
+   * @default true
+   */
+  useZoraUsernameResolution: true,
    
   /**
    * Flag if showing the nft owner on full view

--- a/yarn.lock
+++ b/yarn.lock
@@ -2904,10 +2904,10 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zoralabs/nft-hooks@^0.7.1":
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/@zoralabs/nft-hooks/-/nft-hooks-0.7.1.tgz#2169daaf48938c4334fcef28ff373f7be6c8897d"
-  integrity sha512-w/dr1F+kNZ2rHKFDEm5JC5DH1F9Ga/NUiKTYifBZ0CT5eWPvx0J6s/TMfoPmmW/h53YyEousYBchcBX5sCiQPg==
+"@zoralabs/nft-hooks@^0.7.2":
+  version "0.7.2"
+  resolved "https://registry.yarnpkg.com/@zoralabs/nft-hooks/-/nft-hooks-0.7.2.tgz#5a11a3eba62c41d38ab4871b65575d37032da3db"
+  integrity sha512-aWxXDSAs3pgcKLUFacRJlhAw9IczIs8S70byHC7K+1TuwU4FK94CasFHm41cwjiNJsOnRl+hOD6HjNwYRPxyIg==
   dependencies:
     "@ethersproject/address" "^5.4.0"
     big.js "^6.1.0"


### PR DESCRIPTION
Pretty straightforward

- if nft data has openseaInfo that is used for the contract name & icon - otherwise defaults to zoraNft.
- Placement is above title and below media by default - if we stick to this perhaps remove the top margin on the title h2 element?

![Screen Shot 2021-10-18 at 5 16 36 PM](https://user-images.githubusercontent.com/7268786/137823811-85254659-2b73-4db1-a256-7e0a86db1252.png)


