### PR TITLE
Update PlaceOfferButton URL

### DIFF
--- a/src/nft-full/PlaceOfferButton.tsx
+++ b/src/nft-full/PlaceOfferButton.tsx
@@ -39,9 +39,10 @@ export const PlaceOfferButton = ({ allowOffer }: PlaceOfferButtonProps) => {
     ) {
       return [
         ZORA_SITE_URL_BASE,
-        "auction",
+        "collections",
         data.nft.contract.address,
         data.nft.tokenId,
+        "auction",
         "bid",
       ];
     }


### PR DESCRIPTION
The URL scheme changed for Zora bid links has changed. As a result, the PlaceOfferButton in nft-components no longer works. This pull request will update the button to use the new scheme. [https://zora.co/COLLECTIONS/CONTRACT_ID/TOKEN_ID/auction/bid]