### PR TITLE
getBidURLParts function now compatible with .co

### DIFF
--- a/src/nft-full/PlaceOfferButton.tsx
+++ b/src/nft-full/PlaceOfferButton.tsx
@@ -33,6 +33,9 @@ export const PlaceOfferButton = ({ allowOffer }: PlaceOfferButtonProps) => {
     if (!data) {
       return;
     }
+    if (data.pricing.auctionType !== AuctionType.RESERVE && data.nft.contract.knownContract !== 'zora') {
+      return;
+    }
     return [
       ZORA_SITE_URL_BASE,
       "collections",

--- a/src/nft-full/PlaceOfferButton.tsx
+++ b/src/nft-full/PlaceOfferButton.tsx
@@ -33,25 +33,12 @@ export const PlaceOfferButton = ({ allowOffer }: PlaceOfferButtonProps) => {
     if (!data) {
       return;
     }
-    if (
-      data.nft.contract.knownContract !== "zora" &&
-      data.pricing.auctionType === AuctionType.RESERVE
-    ) {
-      return [
-        ZORA_SITE_URL_BASE,
-        "collections",
-        data.nft.contract.address,
-        data.nft.tokenId,
-        "auction",
-        "bid",
-      ];
-    }
-
     return [
       ZORA_SITE_URL_BASE,
-      data.nft.creator,
+      "collections",
+      data.nft.contract.address,
       data.nft.tokenId,
-      data.pricing.auctionType === AuctionType.RESERVE ? "auction/bid" : "bid",
+      data.pricing.auctionType === AuctionType.RESERVE ? "auction/bid" : "offer",
     ];
   }
 


### PR DESCRIPTION
@iainnash modified the getBidURLParts function / simplified it looks like .co is now pointing to the contact/tokenid for making an offer instead of the creator id if it's a zora token.