### PR TITLE
Removes duplicate mint data from bid history when indexer is being used.

### DIFF
--- a/src/nft-full/BidHistory.tsx
+++ b/src/nft-full/BidHistory.tsx
@@ -82,7 +82,7 @@ export const BidHistory = ({ showPerpetual = true, className }: BidHistoryProps)
       });
     }
 
-    if ("zoraNFT" in data && data.zoraNFT && data.zoraNFT.createdAtTimestamp) {
+    if ("zoraNFT" in data && data.zoraNFT && data.zoraNFT.createdAtTimestamp && !("zoraIndexerResponse" in data)) {
       eventsList.push({
         activityDescription: getString("BID_HISTORY_MINTED"),
         pricing: <Fragment />,


### PR DESCRIPTION
BidHistory is pulling duplicate mint data when indexer is being used. This change prioritizes mint data from zoraIndexerResponse over zoraNFT to resolve duplicate mint entries.