### PR TITLE
Fixes issue where bid history mint date was not formatted properly

### DIFF
--- a/src/nft-full/BidHistory.tsx
+++ b/src/nft-full/BidHistory.tsx
@@ -92,14 +92,19 @@ export const BidHistory = ({ showPerpetual = true, className }: BidHistoryProps)
       });
     }
 
-    if ('zoraIndexerResponse' in data && data.zoraIndexerResponse.minter) {
+    if ("zoraIndexerResponse" in data && data.zoraIndexerResponse.minter) {
+      const unixDate =
+        new Date(
+          data.zoraIndexerResponse.mintTransferEvent?.blockTimestamp
+        ).getTime() / 1000;
+
       eventsList.push({
-        activityDescription: getString('BID_HISTORY_MINTED'),
+        activityDescription: getString("BID_HISTORY_MINTED"),
         pricing: <Fragment />,
         actor: data.zoraIndexerResponse.minter,
-        createdAt: data.zoraIndexerResponse.mintTransferEvent?.blockTimestamp,
+        createdAt: unixDate.toString(),
         transactionHash: null,
-      })
+      });
     }
 
     if ("openseaInfo" in data && data.openseaInfo.creator) {


### PR DESCRIPTION
Zora indexer mint date is not in unix time. This creates and issue where the date formatter works incorrectly on the BidHistory component. Converting to unix time solves the issue.