### PR TITLE
Adding theme option for preferred IPFS gateway

### DIFF
--- a/src/constants/theme.ts
+++ b/src/constants/theme.ts
@@ -28,6 +28,12 @@ export const ThemeOptions = {
   useEnsResolution: true,
 
   /**
+   * Set an overriding preferred IPFS provider here
+   * Include a trailing slash
+   */
+  preferredIPFSGateway: 'https://ipfs.io/ipfs/',
+
+  /**
    * Flag if zora username resolution should be automatically used
    * @default true
    */

--- a/src/content-components/Audio.tsx
+++ b/src/content-components/Audio.tsx
@@ -117,6 +117,7 @@ export const AudioRenderer = forwardRef<HTMLAudioElement, RenderComponentType>(
       request,
       a11yIdPrefix,
       getStyles,
+      preferredIPFSGateway: theme.preferredIPFSGateway,
     });
 
     const audioRef = useRef<HTMLAudioElement>(null);

--- a/src/content-components/HTML.tsx
+++ b/src/content-components/HTML.tsx
@@ -8,9 +8,10 @@ import {
 } from "./RendererConfig";
 
 const HTMLRenderer = (requestProps: RenderComponentType) => {
-  const { getStyles, request } = requestProps;
+  const { getStyles, request, theme } = requestProps;
   const { props, loading, error } = useMediaObjectProps({
     uri: request.media.content?.uri || request.media.animation?.uri,
+    preferredIPFSGateway: theme.preferredIPFSGateway,
     ...requestProps,
   });
   const [windowHeight, setWindowHeight] = useState<number>(

--- a/src/content-components/Image.tsx
+++ b/src/content-components/Image.tsx
@@ -9,9 +9,10 @@ import {
 
 export const ImageRenderer = forwardRef<HTMLImageElement, RenderComponentType>(
   (requestProps, ref) => {
-    const { getStyles, request } = requestProps;
+    const { getStyles, theme, request } = requestProps;
     const { props, loading, error } = useMediaObjectProps({
       uri: request.media.content?.uri || request.media.image?.uri,
+      preferredIPFSGateway: theme.preferredIPFSGateway,
       ...requestProps,
     });
 

--- a/src/content-components/MediaLoader.tsx
+++ b/src/content-components/MediaLoader.tsx
@@ -1,13 +1,23 @@
 import React, { useState } from "react";
 import type { RenderRequest } from "./RendererConfig";
 
-function getNormalizedURI(uri: string) {
+function getNormalizedURI(
+  uri: string,
+  { preferredIPFSGateway }: { preferredIPFSGateway?: string }
+) {
   if (uri.startsWith("ipfs://")) {
-    return uri.replace("ipfs://", "https://ipfs.io/ipfs/");
+    return uri.replace(
+      "ipfs://",
+      preferredIPFSGateway || "https://ipfs.io/ipfs/"
+    );
   }
-  if (uri.startsWith("arweave://")) {
-    return uri.replace("arweave://", "https://arweave.net/");
+  if (uri.includes("/ipfs/") && preferredIPFSGateway) {
+    return `${preferredIPFSGateway}${uri.replace(/^.+\/ipfs\//, "")}`;
   }
+  if (uri.startsWith("ar://")) {
+    return uri.replace("ar://", "https://arweave.net/");
+  }
+
   return uri;
 }
 
@@ -16,11 +26,13 @@ export function useMediaObjectProps({
   request,
   a11yIdPrefix,
   getStyles,
+  preferredIPFSGateway,
 }: {
   uri: string | undefined;
   request: RenderRequest;
   a11yIdPrefix?: string;
   getStyles: any;
+  preferredIPFSGateway?: string;
 }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string>();
@@ -34,10 +46,10 @@ export function useMediaObjectProps({
       onLoad: () => setLoading(false),
       // TODO(iain): Update Error
       onError: () => setError("Error loading"),
-      src: uri ? getNormalizedURI(uri) : uri,
+      src: uri ? getNormalizedURI(uri, { preferredIPFSGateway }) : uri,
       ...getStyles("mediaObject", undefined, {
         mediaLoaded: !loading,
-        isFullPage: request.renderingContext === "FULL"
+        isFullPage: request.renderingContext === "FULL",
       }),
     },
   };

--- a/src/content-components/Video.tsx
+++ b/src/content-components/Video.tsx
@@ -13,7 +13,7 @@ import { useA11yIdPrefix } from "../utils/useA11yIdPrefix";
 
 export const VideoRenderer = forwardRef<HTMLVideoElement, RenderComponentType>(
   (props, ref) => {
-    const { getString, getStyles, request, a11yIdPrefix } = props;
+    const { getString, getStyles, request, theme, a11yIdPrefix } = props;
     const [isPlaying, setIsPlaying] = useState(true);
     const [isMuted, setIsMuted] = useState(true);
     const [isFullScreen, setIsFullScreen] = useState(false);
@@ -34,6 +34,7 @@ export const VideoRenderer = forwardRef<HTMLVideoElement, RenderComponentType>(
       request,
       a11yIdPrefix,
       getStyles,
+      preferredIPFSGateway: theme.preferredIPFSGateway,
     });
 
     useSyncRef(video, ref);


### PR DESCRIPTION
This overrides IPFS gateways to prevent overloading IPFS gateways such as pinata by relying on a gateway that can support more requests.