### PR TITLE
WIP: title fallback using contract name and tokenID

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@emotion/css": "^11.1.3",
     "@types/react": "^17.0.5",
-    "@zoralabs/nft-hooks": "^0.7.2",
+    "@zoralabs/nft-hooks": "^0.8.1",
     "merge-anything": "^4.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",

--- a/src/nft-full/CollectionTag.tsx
+++ b/src/nft-full/CollectionTag.tsx
@@ -12,6 +12,8 @@ export const CollectionTag = () => {
   
   const { getStyles } = useMediaContext();
 
+  console.log(data)
+
   const getContent = () => {
     return (
       <a
@@ -21,16 +23,13 @@ export const CollectionTag = () => {
         rel="noreferrer"
       >
         <div {...getStyles("collectionTagIcon")}>
-          {data && "openseaInfo" in data
-            ? <img src={data.openseaInfo.asset_contract.image_url} alt={data.openseaInfo.asset_contract.name}/>
+          {data && "openseaInfo" in data && data.openseaInfo.asset_contract.image_url !== null
+            ? <img src={data.openseaInfo.asset_contract.image_url} alt={data?.nft.contract.name}/>
             : <Orb />
           }
         </div>
         <span>
-          {data && "openseaInfo" in data
-            ? `${data?.openseaInfo.asset_contract.name}`
-            : `${data?.nft.contract.name}` 
-          }
+          {data && data?.nft.contract.name}
         </span>
       </a>
     )

--- a/src/nft-full/CollectionTag.tsx
+++ b/src/nft-full/CollectionTag.tsx
@@ -7,11 +7,11 @@ import { Orb } from "../components/Orb";
 
 export const CollectionTag = () => {
   const {
-    nft: { data },
+    nft: { data }
   } = useContext(NFTDataContext);
- 
-  const { getStyles } = useMediaContext();
   
+  const { getStyles } = useMediaContext();
+
   const getContent = () => {
     return (
       <a
@@ -21,12 +21,17 @@ export const CollectionTag = () => {
         rel="noreferrer"
       >
         <div {...getStyles("collectionTagIcon")}>
-          {/* @ts-ignore */ data && "openseaInfo" in data
+          {data && "openseaInfo" in data
             ? <img src={data.openseaInfo.asset_contract.image_url} alt={data.openseaInfo.asset_contract.name}/>
             : <Orb />
           }
         </div>
-        <span>{data && "openseaInfo" in data ? `${data.openseaInfo.asset_contract.name}` : 'Zora'}</span>
+        <span>
+          {data && "openseaInfo" in data
+            ? `${data?.openseaInfo.asset_contract.name}`
+            : `${data?.nft.contract.name}` 
+          }
+        </span>
       </a>
     )
   }

--- a/src/nft-full/MediaInfo.tsx
+++ b/src/nft-full/MediaInfo.tsx
@@ -19,7 +19,7 @@ export const MediaInfo = ({ a11yIdPrefix, className }: MediaInfoProps) => {
   const getContent = () => {
     if (metadata && data) {
       return {
-        title: metadata.name,
+        title: metadata.name !== null ? metadata.name : `${"openseaInfo" in data && data.openseaInfo.asset_contract.name} #${data.nft.tokenId}`,
         description: metadata.description,
       };
     }

--- a/src/nft-full/MediaInfo.tsx
+++ b/src/nft-full/MediaInfo.tsx
@@ -19,7 +19,11 @@ export const MediaInfo = ({ a11yIdPrefix, className }: MediaInfoProps) => {
   const getContent = () => {
     if (metadata && data) {
       return {
-        title: metadata.name !== null ? metadata.name : `${"openseaInfo" in data && data.openseaInfo.asset_contract.name} #${data.nft.tokenId}`,
+        title: metadata.name === undefined  || metadata.name === null ?
+          (`${data && "openseaInfo" in data
+            ? data?.openseaInfo.asset_contract.name
+            : data?.nft.contract.name
+          } #${data.nft.tokenId}`) : metadata.name,
         description: metadata.description,
       };
     }

--- a/src/nft-full/MediaInfo.tsx
+++ b/src/nft-full/MediaInfo.tsx
@@ -18,12 +18,10 @@ export const MediaInfo = ({ a11yIdPrefix, className }: MediaInfoProps) => {
 
   const getContent = () => {
     if (metadata && data) {
+      console.log(metadata)
       return {
         title: metadata.name === undefined  || metadata.name === null ?
-          (`${data && "openseaInfo" in data
-            ? data?.openseaInfo.asset_contract.name
-            : data?.nft.contract.name
-          } #${data.nft.tokenId}`) : metadata.name,
+          (`${data?.nft.contract.name} #${data.nft.tokenId}`) : metadata.name,
         description: metadata.description,
       };
     }

--- a/src/stories/NFTFull.stories.tsx
+++ b/src/stories/NFTFull.stories.tsx
@@ -93,3 +93,9 @@ CryptovoxelsParcel.args = {
   id: "10",
   contract: "0x79986aF15539de2db9A5086382daEdA917A9CF0C",
 };
+
+export const MutantApeYachtClub = Template.bind({});
+MutantApeYachtClub.args = {
+  id: "6721",
+  contract: "0x60E4d786628Fea6478F785A6d7e704777c86a7c6",
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1352,6 +1352,13 @@
   dependencies:
     "@ethersproject/logger" "^5.4.0"
 
+"@ethersproject/bytes@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/bytes/-/bytes-5.5.0.tgz#cb11c526de657e7b45d2e0f0246fb3b9d29a601c"
+  integrity sha512-ABvc7BHWhZU9PNM/tANm/Qx4ostPGadAuQzWTr3doklZOhDlmcBqclrQe/ZXUIj3K8wC28oYeuRa+A37tX9kog==
+  dependencies:
+    "@ethersproject/logger" "^5.5.0"
+
 "@ethersproject/keccak256@^5.4.0":
   version "5.4.0"
   resolved "https://registry.npmjs.org/@ethersproject/keccak256/-/keccak256-5.4.0.tgz"
@@ -1364,6 +1371,11 @@
   version "5.4.0"
   resolved "https://registry.npmjs.org/@ethersproject/logger/-/logger-5.4.0.tgz"
   integrity sha512-xYdWGGQ9P2cxBayt64d8LC8aPFJk6yWCawQi/4eJ4+oJdMMjEBMrIcIMZ9AxhwpPVmnBPrsB10PcXGmGAqgUEQ==
+
+"@ethersproject/logger@^5.5.0":
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/@ethersproject/logger/-/logger-5.5.0.tgz#0c2caebeff98e10aefa5aef27d7441c7fd18cf5d"
+  integrity sha512-rIY/6WPm7T8n3qS2vuHTUBPdXHl+rGxWxW5okDfo9J4Z0+gRRZT0msvUdIJkE4/HS29GUMziwGaaKO2bWONBrg==
 
 "@ethersproject/rlp@^5.4.0":
   version "5.4.0"
@@ -2904,12 +2916,13 @@
   resolved "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz"
   integrity sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==
 
-"@zoralabs/nft-hooks@^0.7.2":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@zoralabs/nft-hooks/-/nft-hooks-0.7.2.tgz#5a11a3eba62c41d38ab4871b65575d37032da3db"
-  integrity sha512-aWxXDSAs3pgcKLUFacRJlhAw9IczIs8S70byHC7K+1TuwU4FK94CasFHm41cwjiNJsOnRl+hOD6HjNwYRPxyIg==
+"@zoralabs/nft-hooks@^0.8.1":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@zoralabs/nft-hooks/-/nft-hooks-0.8.1.tgz#7f66516c44eac6160b4a5d8bfff47544b0cda345"
+  integrity sha512-Flc4s87KhAnXKxubyELVWfydc8FYu+uiZPl1pvIwvuTTsBPEAUKMTepGkkLivrJFPQ47a++hsUGMHRPnTvhDbA==
   dependencies:
     "@ethersproject/address" "^5.4.0"
+    "@ethersproject/bytes" "^5.5.0"
     big.js "^6.1.0"
     cross-fetch "^3.1.4"
     dataloader "^2.0.0"
@@ -2918,6 +2931,7 @@
     node-abort-controller "^2.0.0"
     react "^17.0.2"
     react-test-renderer "^17.0.2"
+    sha3 "^2.1.4"
     swr "^0.5.6"
     tslib "^2.2.0"
 
@@ -3505,7 +3519,7 @@ balanced-match@^1.0.0:
   resolved "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
-base64-js@^1.0.2:
+base64-js@^1.0.2, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -3758,6 +3772,14 @@ buffer-xor@^1.0.3:
   version "1.0.3"
   resolved "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
+
+buffer@6.0.3:
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-6.0.3.tgz#2ace578459cc8fbe2a70aaa8f52ee63b6a74c6c6"
+  integrity sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==
+  dependencies:
+    base64-js "^1.3.1"
+    ieee754 "^1.2.1"
 
 buffer@^4.3.0:
   version "4.9.2"
@@ -6256,7 +6278,7 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
   dependencies:
     postcss "^7.0.14"
 
-ieee754@^1.1.4:
+ieee754@^1.1.4, ieee754@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz"
   integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
@@ -9789,6 +9811,13 @@ sha.js@^2.4.0, sha.js@^2.4.8:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
+
+sha3@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/sha3/-/sha3-2.1.4.tgz#000fac0fe7c2feac1f48a25e7a31b52a6492cc8f"
+  integrity sha512-S8cNxbyb0UGUM2VhRD4Poe5N58gJnJsLJ5vC7FYWGUmGhcsj4++WaIOBFVDxlG0W3To6xBuiRh+i0Qp2oNCOtg==
+  dependencies:
+    buffer "6.0.3"
 
 shallow-clone@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
@iainnash this would be a nice feature so we "always" have a title available for the Token.
I did notice that when using betaIndexer the contract title & symbol are not available, so perhaps we include this in  nft-hooks query, or simply surface the contract name and symbol in the nft object.

<img width="613" alt="Screen Shot 2021-12-02 at 3 06 43 PM" src="https://user-images.githubusercontent.com/7268786/144517341-3897e253-cd39-4012-b3e2-035488947fd9.png">

![Screen Shot 2021-12-02 at 2 55 24 PM](https://user-images.githubusercontent.com/7268786/144517414-0455f3fe-6e21-4ab9-9a00-1d01ad363575.png)

![Screen Shot 2021-12-02 at 2 55 17 PM](https://user-images.githubusercontent.com/7268786/144517425-0c507694-b9d6-4a87-bc16-f595ee6bb465.png)
