### PR TITLE
parse mintTransferEvent createdAt as UTC

### DIFF
--- a/src/nft-full/BidHistory.tsx
+++ b/src/nft-full/BidHistory.tsx
@@ -95,7 +95,7 @@ export const BidHistory = ({ showPerpetual = true, className }: BidHistoryProps)
     if ("zoraIndexerResponse" in data && data.zoraIndexerResponse.minter) {
       const unixDate =
         new Date(
-          data.zoraIndexerResponse.mintTransferEvent?.blockTimestamp
+          data.zoraIndexerResponse.mintTransferEvent?.blockTimestamp + "Z"
         ).getTime() / 1000;
 
       eventsList.push({


### PR DESCRIPTION
Fixes an issue caused by `blockTimestamp` being a UTC datetime (i think at least, lining it up with the tx on etherscan), but doesn't include a TZ indicator, [which causes it to be parsed in device time](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/parse#date_time_string_format).