### PR TITLE
fix: s/overideen/overridden

### DIFF
--- a/src/stories/CustomMediaObjects.stories.mdx
+++ b/src/stories/CustomMediaObjects.stories.mdx
@@ -7,7 +7,7 @@ import { CustomMedia } from "./CustomMedia";
 
 Zora's NFT Components allow for custom rendering components that are selected based on the mime type of the content.
 
-These components can be upgraded or overrideen.
+These components can be upgraded or overridden.
 
 The main `mediaRenderer` configuration dictionary defines what renderers to show in different states.
 Key states are `error` and `unknown`, states for `text:` and `uri:` are prefixes followed by partial or full content-types.


### PR DESCRIPTION
## Summary

Closes #116

This fixes a typographical error in the Custom Media Components documentation page.