### PR TITLE
Check to ensure contract image is set before using in collection tag

### DIFF
--- a/src/nft-full/CollectionTag.tsx
+++ b/src/nft-full/CollectionTag.tsx
@@ -21,7 +21,7 @@ export const CollectionTag = () => {
         rel="noreferrer"
       >
         <div {...getStyles("collectionTagIcon")}>
-          {/* @ts-ignore */ data && "opensea" in data.rawData
+          {/* @ts-ignore */ data && "opensea" in data.rawData && data.rawData.opensea.asset_contract.image_url
             ? <img src={data.rawData.opensea.asset_contract.image_url} alt={data.rawData.opensea.asset_contract.name}/>
             : <Orb />
           }


### PR DESCRIPTION
Collection tag would always try to render an image tag even if there was no image in the opensea data.