### PR TITLE
Changes media object to match new metadata typing

### DIFF
--- a/src/components/MediaObject.tsx
+++ b/src/components/MediaObject.tsx
@@ -10,8 +10,8 @@ type MetadataIsh = {
   description: string;
 
   // Only used for non-zora NFTs
-  animation_url?: string;
-  image?: string;
+  contentUri?: string;
+  imageUri?: string;
 };
 
 type MediaObjectProps = {
@@ -31,7 +31,7 @@ export const MediaObject = ({
   tokenId,
   isFullPage = false,
 }: MediaObjectProps) => {
-  const mediaType = useNFTContent(contentURI ?? metadata?.animation_url);
+  const mediaType = useNFTContent(contentURI ?? metadata?.contentUri);
   const { getStyles, getString, renderers, style, networkId } =
     useMediaContext();
 
@@ -48,16 +48,16 @@ export const MediaObject = ({
               mediaType.content?.mimeType,
           }
         : undefined,
-      image: metadata?.image
+      image: metadata?.imageUri
         ? {
-            uri: metadata?.image,
+            uri: metadata?.imageUri,
             type: "image/",
           }
         : undefined,
       // from metadata.animation_url
-      animation: metadata?.animation_url
+      animation: metadata?.contentUri
         ? {
-            uri: metadata?.animation_url,
+            uri: metadata?.contentUri,
             type: mediaType.content?.mimeType,
           }
         : undefined,
@@ -70,6 +70,8 @@ export const MediaObject = ({
   };
 
   const renderingInfo = useMemo(() => {
+    console.log("Rendering input", { contentURI, metadata });
+    console.log("Rendering request", { request });
     const sortedRenderers = renderers.sort((a, b) =>
       a.getRenderingPreference(request) > b.getRenderingPreference(request)
         ? -1


### PR DESCRIPTION
Media object was trying to pull image and animation_url from metadata but strategies now return metadata as imageUri and contentUri