### PR TITLE
build: sync node version in circle ci with nft-hooks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 env_defaults: &env_defaults
   working_directory: ~
   docker:
-    - image: circleci/node:14.15.1
+    - image: cimg/node:16.10.0
 
 version: 2.1
 jobs:


### PR DESCRIPTION
The build was failing as the `graphql` dependency no longer supports <14.16.x. From the build:
```
#!/bin/bash -eo pipefail
if [[ ! -z "" ]]; then
  echo "Running override package installation command:"
  
else
  yarn install --frozen-lockfile
fi

yarn install v1.22.5
[1/4] Resolving packages...
[2/4] Fetching packages...
error graphql@16.5.0: The engine "node" is incompatible with this module. Expected version "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0". Got "14.15.1"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.

Exited with code exit status 1

CircleCI received exit code 1
```

In order to kick off the build again and to be able to run tests, since the premise of nft-component is that it is built on top of nft-hooks, syncing the node version with: https://github.com/ourzora/nft-hooks/blob/6f0b9635b196051a5ff1242ebbf8e1335a742f6c/.circleci/config.yml#L4